### PR TITLE
Added support for RAK3401 + RAK13302 (RAK WisMesh 1W)

### DIFF
--- a/BLESerial.cpp
+++ b/BLESerial.cpp
@@ -117,7 +117,6 @@ void BLESerial::begin(const char *name) {
 
   ble_server = BLEDevice::createServer();
   ble_server->setCallbacks(this);
-  BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT_MITM);
   BLEDevice::setSecurityCallbacks(this);
 
   SetupSerialService();

--- a/Boards.h
+++ b/Boards.h
@@ -115,6 +115,11 @@
   #define BOARD_RAK4631       0x51
   #define MODEL_11            0x11 // RAK4631, 433 Mhz
   #define MODEL_12            0x12 // RAK4631, 868 Mhz
+  #define BOARD_RAK3401       0x52 // RAK3401 + RAK13302 (nRF52840 + SX1262 + SKY66122 1W FEM)
+  #define MODEL_13            0x13 // RAK3401 + RAK13302, 433 MHz
+  #define MODEL_14            0x14 // RAK3401 + RAK13302, 868 MHz
+
+  #define PIN_3V3_EN          34   // WB_IO2 — 5V boost + 3V3_S rail (RAK13302 FEM)
 
   #define PRODUCT_HMBRW       0xF0
   #define BOARD_HMBRW         0x32
@@ -158,7 +163,7 @@
   #endif
 
   #ifndef MODEM
-    #if BOARD_MODEL == BOARD_RAK4631
+    #if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
       #define MODEM SX1262
     #elif BOARD_MODEL == BOARD_GENERIC_NRF52
       #define MODEM SX1262
@@ -777,6 +782,68 @@
       const int pin_led_rx = LED_BLUE;
       const int pin_led_tx = LED_GREEN;
       const int pin_tcxo_enable = -1;
+
+    #elif BOARD_MODEL == BOARD_RAK3401
+      #define HAS_EEPROM false
+      #define HAS_DISPLAY false      // RAK19007 base board has no display in this kit
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_CONSOLE false
+      #define HAS_PMU false
+      #define HAS_NP false
+      #define HAS_SD false
+      #define HAS_TCXO true
+      #define HAS_RF_SWITCH_RX_TX true
+      #define HAS_BUSY true
+      #define HAS_INPUT true
+      #define DIO2_AS_RF_SWITCH true   // SKY66122 CTX driven by DIO2 (hardware TX/RX switch)
+      #define CONFIG_UART_BUFFER_SIZE 6144
+      #define CONFIG_QUEUE_SIZE 6144
+      #define CONFIG_QUEUE_MAX_LENGTH 200
+      #define EEPROM_SIZE 296
+      #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
+      #define BLE_MANUFACTURER "RAK Wireless"
+      #define BLE_MODEL "RAK3401"
+
+      // RAK13302 SKY66122-11 FEM: +8 dBm PA gain (constant per datasheet),
+      // 30 dBm (1 W) max output. Gain values from Meshtastic config.
+      // LORA_LNA_GAIN corrects RSSI for the +11-13 dB LNA (midpoint 12).
+      #define HAS_LORA_PA    true
+      #define PA_MAX_OUTPUT  30
+      #define PA_GAIN_POINTS 22
+      #define PA_GAIN_VALUES 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 8
+
+      #define HAS_LORA_LNA   true
+      #define LORA_LNA_GAIN  12
+      #define LORA_LNA_GVT   8
+
+      // SKY66122 FEM is controlled via pin_rxen (WB_IO3) and SX1262 DIO2 (DIO2_AS_RF_SWITCH).
+      // Use LORA_PA_UNKNOWN so sx126x model-specific branches are skipped.
+      #define LORA_PA_MODEL    LORA_PA_UNKNOWN
+      #define LORA_PA_PWR_EN   34  // WB_IO2 = PIN_3V3_EN (3V3_S FEM power rail)
+      #define LORA_PA_CSD      21  // WB_IO3 = SKY66122 CSD+CPS (same as pin_rxen, stays HIGH)
+      #define LORA_PA_CPS      21  // Tied to CSD on RAK13302
+      #define LORA_PA_CTX      -1  // Driven by SX1262 DIO2 via DIO2_AS_RF_SWITCH (no GPIO)
+      const int PA_GC1109_VALUES[PA_GAIN_POINTS]   = {PA_GAIN_VALUES};
+      const int PA_KCT8103L_VALUES[PA_GAIN_POINTS] = {PA_GAIN_VALUES};
+
+      // RAK13302 SX1262 pins — all on P0 bus.
+      const int pin_rxen = 21;         // IO3 = SKY66122 CSD+CPS FEM power enable (stays HIGH)
+                                       // See also SX126X_POWER_EN in variant.h — same pin.
+      const int pin_txen = -1;         // CTX via DIO2_AS_RF_SWITCH (SX1262 hardware control)
+      const int pin_reset = 4;
+      const int pin_cs = 26;
+      const int pin_sclk = 3;
+      const int pin_mosi = 30;
+      const int pin_miso = 29;
+      const int pin_busy = 9;
+      const int pin_dio = 10;
+      const int pin_led_rx = LED_BLUE;
+      const int pin_led_tx = LED_GREEN;
+      const int pin_tcxo_enable = -1;  // TCXO powered by DIO3 via enableTCXO(), not a GPIO
+
+      // User Input Button
+      const int pin_btn_usr1 = 31;   // AIN1 (WB_A1) on J11 header / connector pin 22
 
     #elif BOARD_MODEL == BOARD_TECHO
       #define _PINNUM(port, pin) ((port) * 32 + (pin))

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -433,11 +433,11 @@ void setup() {
     boot_seq();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_HELTEC32_V4
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_RAK3401 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_HELTEC32_V4
     // Some boards need to wait until the hardware UART is set up before booting
-    // the full firmware. In the case of the RAK4631 and Heltec T114, the line below will wait
-    // until a serial connection is actually established with a master. Thus, it
-    // is disabled on this platform.
+    // the full firmware. In the case of the RAK4631, RAK3401, and Heltec T114,
+    // the line below will wait until a serial connection is actually established
+    // with a master. Thus, it is disabled on this platform.
     while (!Serial);
   #endif
 

--- a/Utilities.h
+++ b/Utilities.h
@@ -384,6 +384,13 @@ extern RNS::Reticulum reticulum;
 		void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
 		void led_id_on()  { }
 		void led_id_off() { }
+	#elif BOARD_MODEL == BOARD_RAK3401
+		void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
+		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
+		void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
+		void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
+		void led_id_on()  { }
+		void led_id_off() { }
 	#elif BOARD_MODEL == BOARD_HELTEC_T114
     // Heltec T114 pulls pins LOW to turn on
     void led_rx_on()  { digitalWrite(pin_led_rx, LOW); }
@@ -1410,6 +1417,8 @@ void setTXPower() {
 
 		if (model == MODEL_11) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_RFO_PIN);
 		if (model == MODEL_12) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_RFO_PIN);
+		if (model == MODEL_13) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_RFO_PIN);
+		if (model == MODEL_14) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_RFO_PIN);
 
 		if (model == MODEL_C6) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_RFO_PIN);
     if (model == MODEL_C7) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_RFO_PIN);
@@ -1762,6 +1771,8 @@ bool eeprom_model_valid() {
   if (model == MODEL_C6 || model == MODEL_C7) {
   #elif BOARD_MODEL == BOARD_RAK4631
   if (model == MODEL_11 || model == MODEL_12) {
+  #elif BOARD_MODEL == BOARD_RAK3401
+  if (model == MODEL_13 || model == MODEL_14) {
 	#elif BOARD_MODEL == BOARD_HUZZAH32
 	if (model == MODEL_FF) {
 	#elif BOARD_MODEL == BOARD_GENERIC_ESP32

--- a/boards/rak3401.json
+++ b/boards/rak3401.json
@@ -1,0 +1,73 @@
+{
+	"build": {
+		"arduino": {
+			"ldscript": "nrf52840_s140_v6.ld"
+		},
+		"core": "nRF5",
+		"cpu": "cortex-m4",
+		"extra_flags": "-DARDUINO_NRF52840_FEATHER -DNRF52840_XXAA",
+		"f_cpu": "64000000L",
+		"hwids": [
+			[
+				"0x239A",
+				"0x8029"
+			],
+			[
+				"0x239A",
+				"0x0029"
+			],
+			[
+				"0x239A",
+				"0x002A"
+			],
+			[
+				"0x239A",
+				"0x802A"
+			]
+		],
+		"usb_product": "WisCore RAK3401 Board",
+		"mcu": "nrf52840",
+		"variant": "rak3401",
+		"variants_dir": "variants",
+		"bsp": {
+			"name": "adafruit"
+		},
+		"softdevice": {
+			"sd_flags": "-DS140",
+			"sd_name": "s140",
+			"sd_version": "6.1.1",
+			"sd_fwid": "0x00B6"
+		},
+		"bootloader": {
+			"settings_addr": "0xFF000"
+		}
+	},
+	"connectivity": [
+		"bluetooth"
+	],
+	"debug": {
+		"jlink_device": "nRF52840_xxAA",
+		"svd_path": "nrf52840.svd"
+	},
+	"frameworks": [
+		"arduino"
+	],
+	"name": "WisCore RAK3401 Board",
+	"upload": {
+		"maximum_ram_size": 248832,
+		"maximum_size": 815104,
+		"speed": 115200,
+		"protocol": "nrfutil",
+		"protocols": [
+			"jlink",
+			"nrfjprog",
+			"nrfutil",
+			"stlink"
+		],
+		"use_1200bps_touch": true,
+		"require_upload_port": true,
+		"wait_for_upload_port": true
+	},
+	"url": "https://www.rakwireless.com",
+	"vendor": "RAKwireless"
+}

--- a/extra_script.py
+++ b/extra_script.py
@@ -138,6 +138,8 @@ def device_provision(env):
             env.Execute("rnodeconf --product 10 --model 12 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "techo" | "techo_local":
             env.Execute("rnodeconf --product 15 --model 17 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
+        case "rak3401":
+            env.Execute("rnodeconf --product 10 --model 14 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "heltec_t114" | "heltec_t114_local":
             env.Execute("rnodeconf --product c2 --model c7 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case _:

--- a/platformio.ini
+++ b/platformio.ini
@@ -854,6 +854,43 @@ lib_deps =
 upload_protocol = nrfutil
 upload_port = /dev/cu.usbmodem101
 
+[env:wiscore_rak3401]
+extends = env:embedded
+platform = nordicnrf52
+board = rak4630
+custom_variant = rak3401
+board_build.partitions = no_ota.csv
+board_build.filesystem = littlefs
+build_src_filter = ${env.build_src_filter} +<variants/rak3401>
+build_unflags =
+	${env:embedded-size-opt.build_unflags}
+	-fno-exceptions    ; Required for exception handling on nordicnrf52
+	-fno-rtti          ; Required for exception handling on nordicnrf52
+	--specs=nano.specs ; Required for exception handling on nordicnrf52
+build_flags =
+	${env:embedded-size-opt.build_flags}
+	-fexceptions        ; Required for exception handling on nordicnrf52
+	-frtti              ; Required for exception handling on nordicnrf52
+	--specs=nosys.specs ; Required for exception handling on nordicnrf52
+	-I variants/rak3401
+	-DBOARD_MODEL=BOARD_RAK3401
+	-DURTN_PATH_TABLE_MAX_RECS=25
+	-DRNS_DEFAULT_ALLOCATOR=RNS_HEAP_ALLOCATOR
+	-DRNS_CONTAINER_ALLOCATOR=RNS_HEAP_ALLOCATOR
+	-DRNS_USE_FS
+	-DHAS_RNS
+	-DUSTORE_USE_INTERNALFS
+	-DUSTORE_USE_FLASHFS
+	;-DUSTORE_USE_UNIVERSALFS
+	;-DRNS_PERSIST_PATHS
+	;-DRNS_MEM_LOG
+	;-DRNS_HEAP_POOL_BUFFER_SIZE=65536
+lib_deps =
+	${env:embedded.lib_deps}
+	https://github.com/attermann/microStore.git
+	https://github.com/attermann/microReticulum.git
+	adafruit/SdFat - Adafruit Fork
+	https://github.com/attermann/Adafruit_SPIFlash#littlefs
 
 
 [env:ttgo-t-beam-local]

--- a/sx126x.cpp
+++ b/sx126x.cpp
@@ -139,6 +139,12 @@ bool sx126x::preInit() {
   #elif BOARD_MODEL == BOARD_TECHO
     SPI.setPins(pin_miso, pin_sclk, pin_mosi);
     SPI.begin();
+  #elif BOARD_MODEL == BOARD_RAK3401
+    // spiModem is already constructed with P0 pins (29/3/30) via Config.h using
+    // the pin_miso/pin_sclk/pin_mosi values from Boards.h. The setPins() call is
+    // defensive and documents intent; SPI.begin() would work without it.
+    SPI.setPins(pin_miso, pin_sclk, pin_mosi); // P0: MISO=29, SCK=3, MOSI=30
+    SPI.begin();
   #else
     SPI.begin();
   #endif
@@ -698,6 +704,9 @@ void sx126x::enableTCXO() {
   #if HAS_TCXO
     #if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_XIAO_S3
       uint8_t buf[4] = {MODE_TCXO_3_3V_6X, 0x00, 0x00, 0xFF};
+    #elif BOARD_MODEL == BOARD_RAK3401
+      // RAK13302 specifies DIO3 TCXO at 1.8V (SX126X_DIO3_TCXO_VOLTAGE 1.8)
+      uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_TBEAM
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_TDECK

--- a/variants/rak3401/WVariant.h
+++ b/variants/rak3401/WVariant.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <nrf.h>
+#include <nrf_soc.h>
+#include <nrf_sdm.h>
+#include <nrf_gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const uint32_t g_ADigitalPinMap[] ;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/variants/rak3401/variant.cpp
+++ b/variants/rak3401/variant.cpp
@@ -1,0 +1,48 @@
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+#include "nrf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+const uint32_t g_ADigitalPinMap[] =
+{
+  // P0
+  0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 ,
+  8 , 9 , 10, 11, 12, 13, 14, 15,
+  16, 17, 18, 19, 20, 21, 22, 23,
+  24, 25, 26, 27, 28, 29, 30, 31,
+
+  // P1
+  32, 33, 34, 35, 36, 37, 38, 39,
+  40, 41, 42, 43, 44, 45, 46, 47
+};
+
+
+void initVariant()
+{
+  // LED1 & LED2
+  pinMode(PIN_LED1, OUTPUT);
+  ledOff(PIN_LED1);
+
+  pinMode(PIN_LED2, OUTPUT);
+  ledOff(PIN_LED2);
+
+  // 3V3 Power Rail
+  pinMode(PIN_3V3_EN, OUTPUT);
+  digitalWrite(PIN_3V3_EN, HIGH);
+
+  // Enable SKY66122 FEM on the RAK13302 module.
+  // CSD and CPS are tied together, routed to IO3 (P0.21).
+  // Must be HIGH before radio init.
+  pinMode(SX126X_POWER_EN, OUTPUT);
+  digitalWrite(SX126X_POWER_EN, HIGH);
+  delay(1);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/variants/rak3401/variant.h
+++ b/variants/rak3401/variant.h
@@ -1,0 +1,165 @@
+#pragma once
+
+#ifndef _VARIANT_RAK3401_
+#define _VARIANT_RAK3401_
+
+#define RAK4630
+
+/** Master clock frequency */
+#define VARIANT_MCK (64000000ul)
+
+#define USE_LFXO // Board uses 32khz crystal for LF
+// define USE_LFRC    // Board uses RC for LF
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+#include <Arduino.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+	/*
+	 * WisBlock Base GPIO definitions
+	 */
+	static const uint8_t WB_IO1 = 17;	   // SLOT_A SLOT_B
+	static const uint8_t WB_IO2 = 34;	   // SLOT_A SLOT_B
+	static const uint8_t WB_IO3 = 21;	   // SLOT_C
+	static const uint8_t WB_IO4 = 4;	   // SLOT_C
+	static const uint8_t WB_IO5 = 9;	   // SLOT_D
+	static const uint8_t WB_IO6 = 10;	   // SLOT_D
+	static const uint8_t WB_SW1 = 33;	   // IO_SLOT
+	static const uint8_t WB_A0 = 5;	   // IO_SLOT
+	static const uint8_t WB_A1 = 31;	   // IO_SLOT
+	static const uint8_t WB_I2C1_SDA = 13; // SENSOR_SLOT IO_SLOT
+	static const uint8_t WB_I2C1_SCL = 14; // SENSOR_SLOT IO_SLOT
+	static const uint8_t WB_I2C2_SDA = 24; // IO_SLOT
+	static const uint8_t WB_I2C2_SCL = 25; // IO_SLOT
+	static const uint8_t WB_SPI_CS = 26;   // IO_SLOT
+	static const uint8_t WB_SPI_CLK = 3;   // IO_SLOT
+	static const uint8_t WB_SPI_MISO = 29; // IO_SLOT
+	static const uint8_t WB_SPI_MOSI = 30; // IO_SLOT
+
+// Number of pins defined in PinDescription array
+#define PINS_COUNT (48)
+#define NUM_DIGITAL_PINS (48)
+#define NUM_ANALOG_INPUTS (6)
+#define NUM_ANALOG_OUTPUTS (0)
+
+// LEDs
+#define PIN_LED1 (35)
+#define PIN_LED2 (36)
+
+#define LED_BUILTIN PIN_LED1
+#define LED_CONN PIN_LED2
+
+#define LED_GREEN PIN_LED1
+#define LED_BLUE PIN_LED2
+
+#define LED_STATE_ON 1 // State when LED is litted
+
+/*
+ * Analog pins
+ */
+#define PIN_A0 (5)	//(3)
+#define PIN_A1 (31) //(4)
+#define PIN_A2 (28)
+#define PIN_A3 (29)
+#define PIN_A4 (30)
+#define PIN_A5 (31)
+#define PIN_A6 (0xff)
+#define PIN_A7 (0xff)
+
+	static const uint8_t A0 = PIN_A0;
+	static const uint8_t A1 = PIN_A1;
+	static const uint8_t A2 = PIN_A2;
+	static const uint8_t A3 = PIN_A3;
+	static const uint8_t A4 = PIN_A4;
+	static const uint8_t A5 = PIN_A5;
+	static const uint8_t A6 = PIN_A6;
+	static const uint8_t A7 = PIN_A7;
+#define ADC_RESOLUTION 14
+
+// Other pins
+#define PIN_AREF (2)
+// NFC pins intentionally left undefined — P0.09 and P0.10 are used by
+// the RAK13302 SX1262 (BUSY and DIO) and must not be claimed by the
+// NFC peripheral.  The Adafruit BSP skips NFCT init when these are absent.
+
+	static const uint8_t AREF = PIN_AREF;
+
+/*
+ * Serial interfaces
+ */
+// TXD1 RXD1 on Base Board
+#define PIN_SERIAL1_RX (15)
+#define PIN_SERIAL1_TX (16)
+
+// Connected to Jlink CDC
+#define PIN_SERIAL2_RX (8)
+#define PIN_SERIAL2_TX (6)
+
+/*
+ * SPI Interfaces
+ *
+ * Primary SPI (SPI0/SPIM2) on P1 — matches stock rak4630 BSP layout.
+ * Secondary SPI (SPI1/SPIM3) on P0 — RAK13302 LoRa bus pins.
+ * spiModem in Config.h explicitly constructs on NRF_SPIM2 with P0 pins
+ * from Boards.h, overriding the BSP's SPI0 pin assignment at runtime.
+ */
+#define SPI_INTERFACES_COUNT 2
+
+#define PIN_SPI_MISO (45)
+#define PIN_SPI_MOSI (44)
+#define PIN_SPI_SCK (43)
+
+#define PIN_SPI1_MISO (29)
+#define PIN_SPI1_MOSI (30)
+#define PIN_SPI1_SCK (3)
+
+	static const uint8_t SS = 42;
+	static const uint8_t MOSI = PIN_SPI_MOSI;
+	static const uint8_t MISO = PIN_SPI_MISO;
+	static const uint8_t SCK = PIN_SPI_SCK;
+
+/*
+ * Wire Interfaces
+ */
+#define WIRE_INTERFACES_COUNT 1
+
+#define PIN_WIRE_SDA (13)
+#define PIN_WIRE_SCL (14)
+
+// QSPI Pins
+#define PIN_QSPI_SCK 3
+#define PIN_QSPI_CS 26
+#define PIN_QSPI_IO0 30
+#define PIN_QSPI_IO1 29
+#define PIN_QSPI_IO2 28
+#define PIN_QSPI_IO3 2
+
+// On-board QSPI Flash
+#define EXTERNAL_FLASH_DEVICES IS25LP080D
+#define EXTERNAL_FLASH_USE_QSPI
+
+// RAK13302 SX1262 + SKY66122 FEM control
+// SKY66122 CSD and CPS are tied together on the RAK13302 PCB, routed to IO3 (P0.21).
+// Setting HIGH enables the FEM (LNA active for RX; PA path available for TX).
+// TX/RX switching (CTX) is driven by SX1262 DIO2 via SetDIO2AsRfSwitchCtrl — no GPIO needed.
+#define SX126X_POWER_EN (21)  // P0.21 = WB_IO3 -> SKY66122 CSD+CPS (FEM enable)
+
+// 5V boost + 3.3V switched peripheral rail (powers RAK13302 FEM).
+// Must be held HIGH during radio operation — do not toggle for power saving.
+#define PIN_3V3_EN (34)
+
+#ifdef __cplusplus
+}
+#endif
+
+/*----------------------------------------------------------------------------
+ *        Arduino objects - C++ only
+ *----------------------------------------------------------------------------*/
+
+#endif


### PR DESCRIPTION
### Support for RAK3401 MCU with RAK13302 PA
***Not ready to merge***

https://store.rakwireless.com/products/wismesh-1w-booster-starter-kit

This is the first thing I've done involving platformio or RNode firmwares and I don't know what I'm doing.
Hopefully someone can spot any obvious issues here. 

Firmware builds and is stable so far with atterman's latest filesystem commits.

```
    -DURTN_PATH_TABLE_MAX_RECS=25
    -DRNS_DEFAULT_ALLOCATOR=RNS_HEAP_ALLOCATOR
    -DRNS_CONTAINER_ALLOCATOR=RNS_HEAP_ALLOCATOR
```

Note to self: Clean/Update PlatformIO lib imports of microReticulum and microStore when merging changes.

#### Issues
- Provisioning after the firmware upload fails; Restarting board and provisioning manually works with the below commands. 
    ```
    rnodeconf --product 10 --model 14 --hwrev 1 --rom /dev/ttyACM0
    rnodeconf --firmware-hash `rnodeconf -L /dev/ttyACM0 | grep "actual firmware hash" | awk '{print $7}'` /dev/ttyACM0`
    ```
- Currently matching the MeshCore setup, only using one SPI bus
    `This should be fixed to allow use of GPS etc. on the second`
- NFC pins left undefined

#### Uncertainties
1 ) `Boards.h / platformio.ini`  - Not sure what the best method is to define the IDs, but this looked okay reusing 0x10 and incrementing. I'm still unsure where the BOARD_RAK3401 ID is used.
```
 #define PRODUCT_RAK4631     0x10
 #define BOARD_RAK4631       0x51
 #define MODEL_11            0x11 // RAK4631, 433 Mhz
 #define MODEL_12            0x12 // RAK4631, 868 Mhz
 #define BOARD_RAK3401       0x52 // RAK3401 + RAK13302 (nRF52840 + SX1262 + SKY66122 1W FEM)
 #define MODEL_13            0x13 // RAK3401 + RAK13302, 433 MHz
 #define MODEL_14            0x14 // RAK3401 + RAK13302, 868 MHz
```

2 ) `boards/rak3401.json` isn't/shouldn't be required and using `4631.json` works. I had issues making it work again, left as 3401 board and variant for now.
I'm not sure what the right way to add the variant is, but tried a few, settling on this setup when it packaged with the rnode_firmware_rak4631.zip filename needed for rnodeconf.

3 ) Provisioning when uploading worked once that I saw. Unsure if it's a timing issue on startup (occasionally requires a reset and provisioning within the next ~5 seconds) or the `platformio.ini` board / variant settings