### PR TITLE
add build flag support for airtime limit

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -193,8 +193,14 @@
 		float longterm_airtime = 0.0;
 		#define current_airtime_bin(void) (millis()%AIRTIME_LONGTERM_MS)/AIRTIME_BINLEN_MS
 	#endif
-	float st_airtime_limit = 0.0;
-	float lt_airtime_limit = 0.0;
+	#ifndef ST_AIRTIME_LIMIT
+		#define ST_AIRTIME_LIMIT 0.0
+	#endif
+	#ifndef LT_AIRTIME_LIMIT
+		#define LT_AIRTIME_LIMIT 0.0
+	#endif
+	float st_airtime_limit = ST_AIRTIME_LIMIT;
+	float lt_airtime_limit = LT_AIRTIME_LIMIT;
 	bool airtime_lock = false;
 
 	bool stat_signal_detected   = false;

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,9 @@ build_flags =
 	; ??? NO
 	;-DLOG_LOCAL_LEVEL=5
 	;-DCONFIG_LOG_DEFAULT_LEVEL=5
+	; Optional airtime limit defaults. Values are fractions: 0.05 = 5%.
+	;-DST_AIRTIME_LIMIT=0.05
+	;-DLT_AIRTIME_LIMIT=0.01
 lib_deps = 
 	ArduinoJson@^7.4.2
 	MsgPack@^0.4.2


### PR DESCRIPTION
Unfortunately, I did not find a way to set airtime limits at runtime with rnodeconf, when in TNC mode. I added the option to add build flags to set airtime limits at compile-time. Airtime limits are essential for respecting duty cycles on most EU frequency bands.