### PR TITLE
fix stuck rx led if noise floor is not sampled

### DIFF
--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -1890,8 +1890,8 @@ void update_modem_status() {
   dcd_led = dcd;
   if (dcd_led) { led_rx_on(); }
   else {
-    if (interference_detected) {
-      if (led_id_filter >= LED_ID_TRIG && noise_floor_sampled) { led_id_on(); }
+    if (interference_detected && noise_floor_sampled) {
+      if (led_id_filter >= LED_ID_TRIG) { led_id_on(); }
     } else {
       if (airtime_lock) { led_indicate_airtime_lock(); }
       else              { led_rx_off(); led_id_off(); }


### PR DESCRIPTION
This pull request makes a minor change to the logic to turn RX led on/off. The change fixes, that the RX led got stuck, if the noise floor is not sampled. It combines two conditions into one for better readability and potentially clearer logic.