### PR TITLE
Fix TX queue deadlock on startup (TNC Mode)

### DIFF
--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -1897,12 +1897,13 @@ void update_modem_status() {
       else              { led_rx_off(); led_id_off(); }
     }
   }
+
+  update_noise_floor();
 }
 
 void check_modem_status() {
   if (millis()-last_status_update >= status_interval_ms) {
     update_modem_status();
-    update_noise_floor();
 
     #if MCU_VARIANT == MCU_ESP32 || MCU_VARIANT == MCU_NRF52
       util_samples[dcd_sample] = dcd;


### PR DESCRIPTION
**The Problem**
When operating in TNC mode with interference avoidance active, the TX queue can become permanently stuck immediately after startup.

**Root Cause**
This bug is triggered if a packet is added to the TX queue before the first execution of update_noise_floor(). This creates a deadlock loop:

1. A pending TX packet causes medium_free() to be called.
2. medium_free() calls update_modem_status(), which resets the last_status_update timer.
3. Because the TX queue is stuck, medium_free() is called continuously.
4. Consequently, check_modem_status() always sees a recent last_status_update, causing it to exit early without ever reaching the update_noise_floor() call.
5. Without a valid noise floor measurement, medium_free() permanently returns false, keeping the TX queue indefinitely stuck.

**The Fix**
This PR resolves the deadlock by moving update_noise_floor() directly inside update_modem_status().

By coupling these two updates, we ensure that the noise floor is always calculated whenever the modem status is updated, guaranteeing that medium_free() has the data it needs to process the queue properly.