### PR TITLE
fix build error when not using FS

### DIFF
--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -260,6 +260,7 @@ RNS::Interface lora_interface(RNS::Type::NONE);
     microStore::FileSystem filesystem{microStore::Adapters::PosixFileSystem()};
   #endif
   #else // RNS_USE_FS
+    #include <microStore/Adapters/NoopFileSystem.h>
     microStore::FileSystem filesystem{microStore::Adapters::NoopFileSystem()};
   #endif // RNS_USE_FS
 #endif  // HAS_RNS


### PR DESCRIPTION
This pull request introduces a small change to the filesystem initialization logic when `RNS_USE_FS` is not defined. Specifically, it ensures that the `NoopFileSystem` adapter is properly included.

- Added `#include <microStore/Adapters/NoopFileSystem.h>` to ensure the `NoopFileSystem` adapter is available when the filesystem is initialized without file system support.