### PR TITLE
Update Display.h

### DIFF
--- a/Display.h
+++ b/Display.h
@@ -86,7 +86,7 @@
   #define DISP_ADDR -1
 #elif BOARD_MODEL == BOARD_TBEAM_S_V1
   #define DISP_RST -1
-  #define DISP_ADDR 0x3C
+  #define DISP_ADDR 0x3D
   #define SCL_OLED 18
   #define SDA_OLED 17
   #define DISP_CUSTOM_ADDR false


### PR DESCRIPTION
Fixed issue with latest T-Beam Supreme where the display address is the wrong default, should be 0x3D not 0x3C