### PR TITLE
add eeprom_flush() in _conf_save(...) functions for nrf52-boards without eeprom

### DIFF
--- a/Utilities.h
+++ b/Utilities.h
@@ -1860,10 +1860,18 @@ void bt_conf_save(bool is_enabled) {
 
 void di_conf_save(uint8_t dint) {
 	eeprom_update(eeprom_addr(ADDR_CONF_DINT), dint);
+  #if !HAS_EEPROM && MCU_VARIANT == MCU_NRF52
+	// have to do a flush because we're only writing 1 byte and it syncs after 8
+    eeprom_flush();
+  #endif
 }
 
 void da_conf_save(uint8_t dadr) {
 	eeprom_update(eeprom_addr(ADDR_CONF_DADR), dadr);
+  #if !HAS_EEPROM && MCU_VARIANT == MCU_NRF52
+	// have to do a flush because we're only writing 1 byte and it syncs after 8
+    eeprom_flush();
+  #endif
 }
 
 void db_conf_save(uint8_t val) {
@@ -1876,6 +1884,10 @@ void db_conf_save(uint8_t val) {
 		}
 		eeprom_update(eeprom_addr(ADDR_CONF_BSET), CONF_OK_BYTE);
 		eeprom_update(eeprom_addr(ADDR_CONF_DBLK), val);
+    #if !HAS_EEPROM && MCU_VARIANT == MCU_NRF52
+	  	// have to do a flush because we're only writing 2 bytes and it syncs after 8
+      	eeprom_flush();
+    #endif
 	#endif
 }
 
@@ -1883,6 +1895,10 @@ void drot_conf_save(uint8_t val) {
 	#if HAS_DISPLAY
 		if (val >= 0x00 and val <= 0x03) {
 			eeprom_update(eeprom_addr(ADDR_CONF_DROT), val);
+    	#if !HAS_EEPROM && MCU_VARIANT == MCU_NRF52
+			// have to do a flush because we're only writing 1 byte and it syncs after 8
+        	eeprom_flush();
+    	#endif
 			hard_reset();
 		}
 	#endif
@@ -1891,12 +1907,20 @@ void drot_conf_save(uint8_t val) {
 void dia_conf_save(uint8_t val) {
 	if (val > 0x00)  { eeprom_update(eeprom_addr(ADDR_CONF_DIA), 0x01); }
 	else             { eeprom_update(eeprom_addr(ADDR_CONF_DIA), 0x00); }
+  #if !HAS_EEPROM && MCU_VARIANT == MCU_NRF52
+    // have to do a flush because we're only writing 2 bytes and it syncs after 8
+    eeprom_flush();
+  #endif
 	hard_reset();
 }
 
 void np_int_conf_save(uint8_t p_int) {
 	eeprom_update(eeprom_addr(ADDR_CONF_PSET), CONF_OK_BYTE);
 	eeprom_update(eeprom_addr(ADDR_CONF_PINT), p_int);
+  #if !HAS_EEPROM && MCU_VARIANT == MCU_NRF52
+	// have to do a flush because we're only writing 2 bytes and it syncs after 8
+    eeprom_flush();
+  #endif
 }
 
 


### PR DESCRIPTION
Config changes were not saved properly without eeprom_flush() because nRF52 boards without real EEPROM use a file-backed EEPROM emulation that is only flushed after multiple byte writes. So a change of a single byte will not be written. This is the same procedure as already implemented in bt_conf_save() for example.