### PR TITLE
feat: optimize BLE advertising intervals, clarify power management constraints

### DIFF
--- a/Bluetooth.h
+++ b/Bluetooth.h
@@ -574,7 +574,19 @@ char bt_devname[11];
       // Use Scan response for Name
       Bluefruit.ScanResponse.addName();
 
-      Bluefruit.Advertising.start(0);
+      /* Start Advertising
+      * - Enable auto advertising if disconnected
+      * - Interval:  fast mode = 200 ms, slow mode = 1000 ms
+      * - Timeout for fast mode is 30 seconds
+      * - Start(timeout) with timeout = 0 will advertise forever (until connected)
+      *
+      * For recommended advertising interval
+      * https://developer.apple.com/library/content/qa/qa1931/_index.html
+      */
+      Bluefruit.Advertising.restartOnDisconnect(true);
+      Bluefruit.Advertising.setInterval(320, 1600); // in unit of 0.625 ms
+      Bluefruit.Advertising.setFastTimeout(30);   // number of seconds in fast mode
+      Bluefruit.Advertising.start(0); // 0 = Don't stop advertising after n seconds.  FIXME, we should stop advertising after X
 
       bt_state = BT_STATE_ON;
      }


### PR DESCRIPTION
This PR introduces power-saving optimizations for the nRF52 (and potentially other) platforms, specifically targeting BLE advertising. It also clarifies the technical constraints regarding CPU Light Sleep within the current firmware architecture to conclude our discussion.

1. BLE Advertising Optimization
By default, the Adafruit Bluefruit library uses very aggressive advertising intervals indefinitely, which causes frequent radio wake-ups and unnecessary power spikes.
Taking inspiration from [Meshtastic's firmware](https://github.com/meshtastic/firmware/blob/952c8251678e26d1948673af6c9d96834fcee7fb/src/platform/nrf52/NRF52Bluetooth.cpp#L154), I have updated the BLE advertising parameters in `Bluetooth.h` to use a power-optimized profile:
- Fast Advertising (200ms interval): Runs for the first 30 seconds to ensure quick discovery and pairing upon boot
- Slow Advertising (1000ms interval): The radio seamlessly drops to a much slower interval after 30 seconds, significantly reducing the baseline power draw while keeping the node discoverable.
- Auto-restart: Explicitly enabled `restartOnDisconnect` so the node securely resumes advertising when a client disconnects (not really related to power saving, but still, a good thing to have)

2. Addressing the "Light Sleep" / `yield()` / `delay()` discussion
Regarding the previous attempts to put the CPU into "Light Sleep" (Tickless Idle) during the `loop()` when the node is idle, you were absolutely correct to question the efficacy of `yield()`. Here is the technical breakdown of why we must currently abandon the CPU sleep idea and maintain the 100% active polling loop:

---

* Why `yield()` saves no power: Under the FreeRTOS scheduler used by the ESP32 and nRF52 cores, `yield()` (`taskYIELD()`) only hands execution to tasks of *equal or higher* priority. The Arduino `loop()` runs at normal priority (1), while the FreeRTOS `Idle` task (which is responsible for calling the hardware `__WFE()` / Wait For Event instruction to sleep the CPU) runs at priority 0. Thus, `yield()` immediately returns execution to the `loop()`, keeping the CPU 100% active, so, pretty much useless to use `yield()` here.
* How Meshtastic achieves power savings: Meshtastic uses a fully event-driven RTOS architecture. Every component runs in its own `OSThread` and blocks on a FreeRTOS Semaphore (`InterruptableDelay`). When a task is blocked on a semaphore, the `Idle` task is allowed to run, which safely puts the CPU to sleep. When a hardware interrupt fires (e.g., LoRa `DIO0`), it "gives" the semaphore and instantly wakes the CPU.
* Why we cannot do this in microReticulum: This firmware uses a single `loop()` based on **polling**. Because incoming Serial/USB data is polled via `buffer_serial()` and not interrupt-driven, the hardware UART buffer (limited to 64 bytes) will overflow in just ~5ms at 115200 baud if it is not read. If we block the main loop for 50ms (or indefinitely on a semaphore) to let the CPU sleep, we will inevitably drop Serial data and corrupt Reticulum frames. 

To summarize, without a massive architectural rewrite to make `microReticulum` fully event-driven like Meshtastic, we cannot safely put the CPU to sleep without risking serial data loss. 

Therefore, this PR focuses purely on the **BLE optimization**, which provides a measurable and perfectly safe reduction in battery consumption without altering the core polling mechanics. The deep-sleep/bricking risk for solar nodes has also been completely removed.
