### PR TITLE
feat(rak4631): implement battery status reporting

### DIFF
--- a/Power.h
+++ b/Power.h
@@ -180,7 +180,7 @@ float pmu_temperature = PMU_TEMP_MIN-1;
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
-#elif BOARD_MODEL == BOARD_RAK4631
+#elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
   #define BAT_V_MIN       3.15
   #define BAT_V_MAX       4.2
   #define BAT_V_CHG       4.48

--- a/Power.h
+++ b/Power.h
@@ -180,6 +180,22 @@ float pmu_temperature = PMU_TEMP_MIN-1;
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
+#elif BOARD_MODEL == BOARD_RAK4631
+  #define BAT_V_MIN       3.15
+  #define BAT_V_MAX       4.2
+  #define BAT_V_CHG       4.48
+  #define BAT_V_FLOAT     4.33
+  #define BAT_SAMPLES     7
+  const uint8_t pin_vbat = 5;
+  float bat_p_samples[BAT_SAMPLES];
+  float bat_v_samples[BAT_SAMPLES];
+  uint8_t bat_samples_count = 0;
+  int bat_discharging_samples = 0;
+  int bat_charging_samples = 0;
+  int bat_charged_samples = 0;
+  bool bat_voltage_dropping = false;
+  float bat_delay_v = 0;
+  float bat_state_change_v = 0;
 #endif
 
 uint32_t last_pmu_update = 0;
@@ -202,7 +218,7 @@ void measure_temperature() {
 }
 
 void measure_battery() {
-  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO
+  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_RAK4631
     battery_installed = true;
     #if BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4
       battery_indeterminate = false;
@@ -220,12 +236,14 @@ void measure_battery() {
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.017165;
     #elif BOARD_MODEL == BOARD_TECHO
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.007067;
+    #elif BOARD_MODEL == BOARD_RAK4631
+      float battery_measurement = (float)(analogRead(pin_vbat)) * 0.005068;
     #else
       float battery_measurement = (float)(analogRead(pin_vbat)) / 4095.0*7.26;
     #endif
 
     bat_v_samples[bat_samples_count%BAT_SAMPLES] = battery_measurement;
-    bat_p_samples[bat_samples_count%BAT_SAMPLES] = ((battery_voltage-BAT_V_MIN) / (BAT_V_MAX-BAT_V_MIN))*100.0;
+    bat_p_samples[bat_samples_count%BAT_SAMPLES] = ((battery_measurement-BAT_V_MIN) / (BAT_V_MAX-BAT_V_MIN))*100.0;
     
     bat_samples_count++;
     if (!battery_ready && bat_samples_count >= BAT_SAMPLES) {
@@ -411,8 +429,12 @@ bool init_pmu() {
     pmu_temp_sensor_ready = true;
   #endif
 
-  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_TECHO
+  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_RAK4631
     pinMode(pin_vbat, INPUT);
+    #if BOARD_MODEL == BOARD_RAK4631
+      analogReference(AR_INTERNAL_3_0);
+      analogReadResolution(10);
+    #endif
     return true;
   #elif BOARD_MODEL == BOARD_HELTEC32_V3
     // there are three version of V3: V3, V3.1, and V3.2


### PR DESCRIPTION
This PR adds battery status reporting (voltage, percentage, and charging/discharging state) for the RAK4631 board.
Currently, the firmware does not report battery telemetry for the RAK4631. The hardware provides a battery voltage divider connected to the AIN3 analog pin (mapped to `A0` / `pin 5` on the Adafruit nRF52 core), which we can read to get the battery telemetry.

### Implementation Details

The voltage calculation and pin mapping parameters were sourced from the [Meshtastic firmware](https://github.com/meshtastic/firmware/blob/master/variants/nrf52840/rak4631/variant.h), which implements this successfully for the same hardware.

- Pin used: 5 (A0 / AIN3)
- ADC Resolution: 10-bit
- ADC Reference Voltage: 3.0V
- Calibration / Divider Multiplier: ~1.73 (as used by Meshtastic).
- Calculation formula: `(analogRead(5) / 1024.0) * 3.0V * 1.73 = analogRead(5) * 0.005068`

**Important Note on ADC Configuration:**

In order for the `0.005068` multiplier to work correctly, the nRF52's ADC must be strictly configured to use a 3.0V internal reference and a 10-bit resolution. Without enforcing this, the default nRF52 core settings (3.6V reference or 14-bit resolution on some variants) cause the battery percentage to artificially clamp to 0%.

### Changes Made
- Added `BOARD_RAK4631` to the battery parameter definitions in `Power.h`.
- Updated `measure_battery()` to apply the specific `0.005068` multiplier for the RAK4631 board when converting the raw analog read into voltage.
- Added `pinMode` initialization for `pin_vbat` in `init_pmu()`.
- Added explicit `analogReference(AR_INTERNAL_3_0)` and `analogReadResolution(10)` calls in `init_pmu()` to ensure the hardware math is correct.
- Fixed the `bat_p_samples` FIR filter to calculate the percentage using the instantaneous `battery_measurement` instead of the trailing moving average.

### Testing

- [x] Compilation succeeds for the RAK4631 target
- [ ] Successfully deployed and working on a Wismesh Tag (ongoing)
