### PR TITLE
feat: report bluetooth battery percentage

### DIFF
--- a/Bluetooth.h
+++ b/Bluetooth.h
@@ -554,6 +554,7 @@ char bt_devname[11];
       // start device information service
       bledis.begin();
       blebas.begin();
+      blebas.write(battery_percent);
 
       // Guard to ensure SerialBT service is not duplicated through BT being power cycled
       if (!SerialBT_init) {
@@ -569,6 +570,9 @@ char bt_devname[11];
 
       // Include bleuart 128-bit uuid
       Bluefruit.Advertising.addService(SerialBT);
+      
+      // Include blebas 16-bit uuid for battery status
+      Bluefruit.Advertising.addService(blebas);
 
       // There is no room for Name in Advertising packet
       // Use Scan response for Name

--- a/Power.h
+++ b/Power.h
@@ -264,7 +264,7 @@ void measure_battery() {
 
     bat_v_samples[bat_samples_count%BAT_SAMPLES] = battery_measurement;
     bat_p_samples[bat_samples_count%BAT_SAMPLES] = ((battery_measurement-BAT_V_MIN) / (BAT_V_MAX-BAT_V_MIN))*100.0;
-    
+
     bat_samples_count++;
     if (!battery_ready && bat_samples_count >= BAT_SAMPLES) {
       battery_ready = true;
@@ -277,13 +277,13 @@ void measure_battery() {
         battery_percent += bat_p_samples[bi];
       }
       battery_percent = battery_percent/BAT_SAMPLES;
-      
+
       battery_voltage = 0;
       for (uint8_t bi = 0; bi < BAT_SAMPLES; bi++) {
         battery_voltage += bat_v_samples[bi];
       }
       battery_voltage = battery_voltage/BAT_SAMPLES;
-      
+
       if (bat_delay_v == 0) bat_delay_v = battery_voltage;
       if (bat_state_change_v == 0) bat_state_change_v = battery_voltage;
       if (battery_percent > 100.0) battery_percent = 100.0;
@@ -332,7 +332,12 @@ void measure_battery() {
       }
 
       #if MCU_VARIANT == MCU_NRF52
-        if (bt_state != BT_STATE_OFF) { blebas.write(battery_percent); }
+        if (bt_state != BT_STATE_OFF) {
+          blebas.write(battery_percent);
+          if (bt_state == BT_STATE_CONNECTED) {
+            blebas.notify(battery_percent);
+          }
+        }
       #endif
 
       // if (bt_state == BT_STATE_CONNECTED) {
@@ -611,7 +616,7 @@ bool init_pmu() {
     // Set the time of pressing the button to turn off
     PMU->setPowerKeyPressOffTime(XPOWERS_POWEROFF_4S);
 
-    return true; 
+    return true;
   #elif BOARD_MODEL == BOARD_TBEAM_S_V1
     Wire1.begin(I2C_SDA, I2C_SCL);
 
@@ -691,7 +696,7 @@ bool init_pmu() {
     PMU->enableBattVoltageMeasure();
 
 
-    return true; 
+    return true;
   #else
     return false;
   #endif


### PR DESCRIPTION
This PR resolves an issue where the battery percentage for the RAK4631 board was completely missing or permanently stuck at `0%` over Bluetooth.

## Changes Made

### 1. BLE Battery Service Fixes (`Bluetooth.h`, `Power.h`)
* [x] Advertising Payload: Added `Bluefruit.Advertising.addService(blebas)` so the Battery Service UUID is properly advertised to scanning devices
* [x] Initial Value Buffer: Added `blebas.write(battery_percent)` immediately after `blebas.begin()`. Without this, the characteristic length is 0 bytes when BlueZ initially queries it upon connection, causing Linux to silently drop the `org.bluez.Battery1` interface
* [x] Live Notifications: Added `blebas.notify(battery_percent)` in the `update_pmu()` routine so connected BLE clients receive automatic updates without needing to actively poll the GATT characteristic

## Testing
*   Compiled for `rak4631`
*   Verified that `bluetoothctl info` on Linux now successfully exposes the `Battery Percentage` characteristic (`0x2A19`) upon connection.
*   Verified that the battery percentage accurately reflects the real battery voltage instead of being clamped to 0%.

```
❯ bluetoothctl info FE:E7:AB:CA:47:C3
Device FE:E7:AB:CA:47:C3 (random)
        Name: RNode 2C68
        Alias: RNode 2C68
        Paired: yes
        Bonded: yes
        Trusted: yes
        Blocked: no
        Connected: yes
        LegacyPairing: no
        CablePairing: no
        UUID: Generic Access Profile    (00001800-0000-1000-8000-00805f9b34fb)
        UUID: Generic Attribute Profile (00001801-0000-1000-8000-00805f9b34fb)
        UUID: Device Information        (0000180a-0000-1000-8000-00805f9b34fb)
        UUID: Battery Service           (0000180f-0000-1000-8000-00805f9b34fb)
        UUID: Nordic UART Service       (6e400001-b5a3-f393-e0a9-e50e24dcca9e)
        AdvertisingFlags:
  06                                               .
        Battery Percentage: 0x64 (100)
        LE.Paired: yes
        LE.Bonded: yes
        LE.Connected: yes
```

<img width="428" height="222" alt="image" src="https://github.com/user-attachments/assets/6c213d79-2a1c-41e9-a514-f3777740e1f5" />

