### PR TITLE
Revert "Adjustments to RAK3402+RAK13302 implementation and enhanced RNode init logging"

### DIFF
--- a/BLESerial.cpp
+++ b/BLESerial.cpp
@@ -117,7 +117,6 @@ void BLESerial::begin(const char *name) {
 
   ble_server = BLEDevice::createServer();
   ble_server->setCallbacks(this);
-  BLEDevice::setEncryptionLevel(ESP_BLE_SEC_ENCRYPT_MITM);
   BLEDevice::setSecurityCallbacks(this);
 
   SetupSerialService();

--- a/Boards.h
+++ b/Boards.h
@@ -775,7 +775,7 @@
       const int pin_reset = 38;
       const int pin_cs = 42;
       const int pin_sclk = 43;
-      const int pin_mosi = MOSI;
+      const int pin_mosi = 44;
       const int pin_miso = 45;
       const int pin_busy = 46;
       const int pin_dio = 47;

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -897,13 +897,11 @@ void setup() {
   try {
     // CBA Init filesystem
     HEAD("Initializing filesystem...", RNS::LOG_TRACE);
-#if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
+#if BOARD_MODEL == BOARD_RAK4631
     // First attempt to initialize RAK15001 flash
     TRACE("Looking for RAK15001 flash...");
     static const SPIFlash_Device_t device_rak15001 = RAK15001;
-    // CBA NOTE: RAK base boards generally *share* the same chip select (CS/SS) across all module slots.
-    // SS below is expected to be configured as the "external" SPI bus chip select.
-    filesystem = microStore::Adapters::FlashFSFileSystem(&device_rak15001, SS);
+    filesystem = microStore::Adapters::FlashFSFileSystem(&device_rak15001);
     if (filesystem.init()) {
       TRACE("Initialized RAK15001 flash");
       // Raise path store limits to account for larger external flash size
@@ -972,7 +970,7 @@ void setup() {
     TRACE("Listing filesystem...");
     dump_filesystem("./", 1, 2);
 #endif
-#endif // RNS_USE_FS
+#endif // !NDEBUG && RNS_USE_FS
 
     // CBA Start RNS
     //if (hw_ready) {
@@ -991,16 +989,16 @@ void setup() {
       }
 #endif
 
-      // Provisioning default
-      reticulum.transport_enabled(true);
-      // Provisioning default
-      reticulum.probe_destination_enabled(true);
-      // Provisioning default
-      reticulum.remote_management_enabled(true);
+    // Provisioning default
+    reticulum.transport_enabled(true);
+    // Provisioning default
+    reticulum.probe_destination_enabled(true);
+    // Provisioning default
+    reticulum.remote_management_enabled(true);
 
 #ifdef URTN_STATS_PAGES
-      // Provisioning default
-      snprintf(nomadnet_name, sizeof(nomadnet_name), "microReticulum Node [%s]", device_uid_str);
+    // Provisioning default
+    snprintf(nomadnet_name, sizeof(nomadnet_name), "microReticulum Node [%s]", device_uid_str);
 #endif
 
 #ifdef HAS_PROVISIONING
@@ -1041,8 +1039,8 @@ void setup() {
       HEAD("Creating Reticulum instance...", RNS::LOG_TRACE);
       reticulum = RNS::Reticulum();
       // CBA NOTE: `transport_enabled` needs to always be overridden to false when op_mode is not MODE_TNC
-printf("hw_ready: %u\n", hw_ready);
-printf("op_mode: %U\n", op_mode);
+TRACEF("hw_ready: %u", hw_ready);
+TRACEF("op_mode: %U", op_mode);
       if (op_mode != MODE_TNC) {
         INFO("Not in TNC mode, transport will be disabled");
         reticulum.transport_enabled(false);
@@ -2442,7 +2440,7 @@ void validate_status() {
 
   if (hw_ready || device_init_done) {
     hw_ready = false;
-    printf("[init] Error, invalid hardware check state\r\n");
+    Serial.write("Error, invalid hardware check state\r\n");
     #if HAS_DISPLAY
       if (disp_ready) {
         device_init_done = true;
@@ -2487,14 +2485,13 @@ void validate_status() {
                 hw_ready = true;
               } else {
                 hw_ready = false;
-                printf("[init] Error, device init failed\r\n");
               }
             #else
               hw_ready = true;
             #endif
           } else {
             hw_ready = false;
-            printf("[init] No radio module found\r\n");
+            Serial.write("No radio module found\r\n");
             #if HAS_DISPLAY
               if (disp_ready) {
                 device_init_done = true;
@@ -2510,7 +2507,7 @@ void validate_status() {
           }
         } else {
           hw_ready = false;
-          printf("[init] Invalid EEPROM checksum\r\n");
+          Serial.write("Invalid EEPROM checksum\r\n");
           #if HAS_DISPLAY
             if (disp_ready) {
               device_init_done = true;
@@ -2520,7 +2517,7 @@ void validate_status() {
         }
       } else {
         hw_ready = false;
-        printf("[init] Invalid EEPROM configuration\r\n");
+        Serial.write("Invalid EEPROM configuration\r\n");
         #if HAS_DISPLAY
           if (disp_ready) {
             device_init_done = true;
@@ -2530,7 +2527,7 @@ void validate_status() {
       }
     } else {
       hw_ready = false;
-      printf("[init] Device unprovisioned, no device configuration found in EEPROM\r\n");
+      Serial.write("Device unprovisioned, no device configuration found in EEPROM\r\n");
       #if HAS_DISPLAY
         if (disp_ready) {
           device_init_done = true;
@@ -2540,7 +2537,7 @@ void validate_status() {
     }
   } else {
     hw_ready = false;
-    printf("[init] Error, incorrect boot vector\r\n");
+    Serial.write("Error, incorrect boot vector\r\n");
     #if HAS_DISPLAY
       if (disp_ready) {
         device_init_done = true;

--- a/Remote.h
+++ b/Remote.h
@@ -128,7 +128,7 @@ void wifi_remote_start_sta() {
   //delay(10000);
   wr_wifi_status = WiFi.status(); 
   printf("[WiFi] status: %d\n", wr_wifi_status);
-  //printf("[WiFi] ip: %s\n", WiFi.localIP());
+	//printf("[WiFi] ip: %s\n", WiFi.localIP());
   wifi_initialized = true;
   wr_last_connect_try = millis();
 }

--- a/Utilities.h
+++ b/Utilities.h
@@ -1739,7 +1739,6 @@ bool eeprom_product_valid() {
 	#endif
 		return true;
 	} else {
-		printf("[init] EEPROM product (%x) invalid\n", rval);
 		return false;
 	}
 }
@@ -1799,7 +1798,6 @@ bool eeprom_model_valid() {
 	#endif
 		return true;
 	} else {
-		printf("[init] EEPROM model (%x) invalid\n", model);
 		return false;
 	}
 }
@@ -1813,7 +1811,6 @@ bool eeprom_hwrev_valid() {
 	if (hwrev != 0x00 && hwrev != 0xFF) {
 		return true;
 	} else {
-		printf("[init] EEPROM hwrev (%x) invalid\n", hwrev);
 		return false;
 	}
 }
@@ -1845,7 +1842,6 @@ bool eeprom_checksum_valid() {
 
 	free(hash);
 	free(data);
-	if (!checksum_valid) printf("[init] EEPROM checksum invalid\n");
 	return checksum_valid;
 }
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -138,10 +138,10 @@ def device_provision(env):
             env.Execute("rnodeconf --product c3 --model c8 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "rak4631" | "rak4631_local":
             env.Execute("rnodeconf --product 10 --model 12 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
-        case "rak3401" | "rak3401_local":
-            env.Execute("rnodeconf --product 10 --model 14 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "techo" | "techo_local":
             env.Execute("rnodeconf --product 15 --model 17 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
+        case "rak3401":
+            env.Execute("rnodeconf --product 10 --model 14 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "heltec_t114" | "heltec_t114_local":
             env.Execute("rnodeconf --product c2 --model c7 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case _:

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,6 @@ default_envs =
 	seeed_xiao_esp32s3
 	generic-esp32
 	wiscore_rak4631
-	wiscore_rak3401
 	lilygo-t-echo
 ; Change source and include directories to root of project since RNode places them here
 include_dir = .
@@ -897,43 +896,6 @@ lib_deps =
 ; SRAM: 256 KB
 ; PSRAM: N/A
 ; Flash: 1 MB internal
-; External Flash Interface: YES (via SPI / QSPI on WisBlock baseboards)
-; LoRa: Semtech SX1262
-[env:wiscore_rak3401]
-extends = env:embedded-nrf52-minimal
-platform = nordicnrf52
-board = rak3401
-custom_variant = rak3401
-board_build.variants_dir = variants
-board_build.variant = rak3401
-;board_build.partitions = no_ota.csv ; Does not apply to nordicnrf52 builds
-board_build.filesystem = littlefs
-build_unflags =
-	${env:embedded-nrf52-minimal.build_unflags}
-build_flags =
-	${env:embedded-nrf52-minimal.build_flags}
-	-DBOARD_MODEL=BOARD_RAK3401
-	-DHAS_GPIO
-	-DHAS_BME
-    -DRNS_CONTAINER_ALLOCATOR=RNS_HEAP_POOL_ALLOCATOR
-    -DRNS_HEAP_POOL_BUFFER_SIZE=131072
-    -DUSTORE_USE_INTERNALFS
-    -DUSTORE_USE_FLASHFS
-	-DURTN_PATH_TABLE_MAX_RECS=25
-	-DRNS_PATH_TABLE_SEGMENT_SIZE=2048 ; 2 KB
-	-DRNS_PATH_TABLE_SEGMENT_COUNT=6
-lib_deps =
-	${env:embedded-nrf52.lib_deps}
-	https://github.com/attermann/microStore.git
-	https://github.com/attermann/microReticulum.git
-    adafruit/SdFat - Adafruit Fork
-    https://github.com/attermann/Adafruit_SPIFlash#littlefs
-    adafruit/Adafruit BME680 Library@^2.0.6
-
-; MCU: Nordic nRF52840 (32-bit ARM Cortex-M4, 64 MHz)
-; SRAM: 256 KB
-; PSRAM: N/A
-; Flash: 1 MB internal
 ; External Flash Interface: N/A
 ; LoRa:  Semtech SX1262
 ; NOTE: Must double-click RESET button (top-left) to enter DFU mode before uploading firmware
@@ -972,9 +934,44 @@ lib_deps =
 upload_protocol = nrfutil
 upload_port = /dev/cu.usbmodem101
 
+[env:wiscore_rak3401]
+extends = env:embedded
+platform = nordicnrf52
+board = rak4630
+custom_variant = rak3401
+board_build.partitions = no_ota.csv
+board_build.filesystem = littlefs
+build_src_filter = ${env.build_src_filter} +<variants/rak3401>
+build_unflags =
+	${env:embedded-size-opt.build_unflags}
+	-fno-exceptions    ; Required for exception handling on nordicnrf52
+	-fno-rtti          ; Required for exception handling on nordicnrf52
+	--specs=nano.specs ; Required for exception handling on nordicnrf52
+build_flags =
+	${env:embedded-size-opt.build_flags}
+	-fexceptions        ; Required for exception handling on nordicnrf52
+	-frtti              ; Required for exception handling on nordicnrf52
+	--specs=nosys.specs ; Required for exception handling on nordicnrf52
+	-I variants/rak3401
+	-DBOARD_MODEL=BOARD_RAK3401
+	-DURTN_PATH_TABLE_MAX_RECS=25
+	-DRNS_DEFAULT_ALLOCATOR=RNS_HEAP_ALLOCATOR
+	-DRNS_CONTAINER_ALLOCATOR=RNS_HEAP_ALLOCATOR
+	-DRNS_USE_FS
+	-DHAS_RNS
+	-DUSTORE_USE_INTERNALFS
+	-DUSTORE_USE_FLASHFS
+	;-DUSTORE_USE_UNIVERSALFS
+	;-DRNS_PERSIST_PATHS
+	;-DRNS_MEM_LOG
+	;-DRNS_HEAP_POOL_BUFFER_SIZE=65536
+lib_deps =
+	${env:embedded.lib_deps}
+	https://github.com/attermann/microStore.git
+	https://github.com/attermann/microReticulum.git
+	adafruit/SdFat - Adafruit Fork
+	https://github.com/attermann/Adafruit_SPIFlash#littlefs
 
-
-; Local dev builds
 
 [env:ttgo-t-beam-local]
 extends = env:embedded-esp32-minimal
@@ -1219,56 +1216,6 @@ build_flags =
 	-DHAS_GPIO
 	-DHAS_BME
 	; CBA TEST
-	;-UNDEBUG
-	;-DRNS_DEFAULT_ALLOCATOR=RNS_HEAP_ALLOCATOR
-	-DRNS_DEFAULT_ALLOCATOR=RNS_HEAP_POOL_ALLOCATOR
-	;-DRNS_CONTAINER_ALLOCATOR=RNS_HEAP_ALLOCATOR
-	-DRNS_CONTAINER_ALLOCATOR=RNS_HEAP_POOL_ALLOCATOR
-	-DRNS_HEAP_POOL_BUFFER_SIZE=131072
-	;-DRNS_HEAP_POOL_BUFFER_SIZE=65536
-	;-UHAS_RNS
-	-DUSTORE_ENABLE_LOG
-    -DUSTORE_USE_INTERNALFS
-    -DUSTORE_USE_FLASHFS
-	-DURTN_PATH_TABLE_MAX_RECS=25
-	-DRNS_PATH_TABLE_SEGMENT_SIZE=2048 ; 2 KB
-	-DRNS_PATH_TABLE_SEGMENT_COUNT=6
-lib_deps =
-	${env:embedded-nrf52.lib_deps}
-	microStore=symlink://../microStore
-	microReticulum=symlink://../microReticulum
-    adafruit/SdFat - Adafruit Fork
-    ;https://github.com/attermann/Adafruit_SPIFlash#littlefs
-	Adafruit_SPIFlash=symlink://../Adafruit_SPIFlash
-    adafruit/Adafruit BME680 Library@^2.0.6
-upload_protocol = nrfutil
-
-; MCU: Nordic nRF52840 (32-bit ARM Cortex-M4, 64 MHz)
-; SRAM: 256 KB
-; PSRAM: N/A
-; Flash: 1 MB internal
-; External Flash Interface: YES (via SPI / QSPI on WisBlock baseboards)
-; LoRa: Semtech SX1262
-[env:wiscore_rak3401-local]
-extends = env:embedded-nrf52-minimal
-platform = nordicnrf52
-;board = rak4630
-board = rak3401
-custom_variant = rak3401_local
-board_build.variants_dir = variants
-;board_build.variant = rak4630
-board_build.variant = rak3401
-;board_build.partitions = no_ota.csv ; Does not apply to nordicnrf52 builds
-board_build.filesystem = littlefs
-build_unflags =
-	${env:embedded-nrf52-minimal.build_unflags}
-build_flags =
-	${env:embedded-nrf52-minimal.build_flags}
-	-DBOARD_MODEL=BOARD_RAK3401
-	-DHAS_GPIO
-	-DHAS_BME
-	; CBA TEST
-	;-UNDEBUG
 	;-DRNS_DEFAULT_ALLOCATOR=RNS_HEAP_ALLOCATOR
 	-DRNS_DEFAULT_ALLOCATOR=RNS_HEAP_POOL_ALLOCATOR
 	;-DRNS_CONTAINER_ALLOCATOR=RNS_HEAP_ALLOCATOR

--- a/variants/rak3401/variant.h
+++ b/variants/rak3401/variant.h
@@ -104,27 +104,22 @@ extern "C"
 /*
  * SPI Interfaces
  *
- * Internal SPI (SPI0/SPIM2) on P1 — This is the internal SPI bus on both RAK4631 and RAK3401, and connects to the internal SX1262 radio on RAK4631.
- * External SPI (SPI1/SPIM3) on P0 — This is the external SPI bus on both RAK4631 and RAK3401 (exported to WisCore IO slots), and is shared with the RAK13302 radio.
+ * Primary SPI (SPI0/SPIM2) on P1 — matches stock rak4630 BSP layout.
+ * Secondary SPI (SPI1/SPIM3) on P0 — RAK13302 LoRa bus pins.
  * spiModem in Config.h explicitly constructs on NRF_SPIM2 with P0 pins
  * from Boards.h, overriding the BSP's SPI0 pin assignment at runtime.
  */
-/*
- * SPI Interfaces
- */
-#define SPI_INTERFACES_COUNT 1
+#define SPI_INTERFACES_COUNT 2
 
-#define PIN_SPI_MISO (29)
-#define PIN_SPI_MOSI (30)
-#define PIN_SPI_SCK (3)
-#define PIN_SPI_CS (26)
+#define PIN_SPI_MISO (45)
+#define PIN_SPI_MOSI (44)
+#define PIN_SPI_SCK (43)
 
-#define PIN_SPI1_MISO (45)
-#define PIN_SPI1_MOSI (44)
-#define PIN_SPI1_SCK (43)
-#define PIN_SPI1_CS (42)
+#define PIN_SPI1_MISO (29)
+#define PIN_SPI1_MOSI (30)
+#define PIN_SPI1_SCK (3)
 
-	static const uint8_t SS = PIN_SPI_CS;
+	static const uint8_t SS = 42;
 	static const uint8_t MOSI = PIN_SPI_MOSI;
 	static const uint8_t MISO = PIN_SPI_MISO;
 	static const uint8_t SCK = PIN_SPI_SCK;


### PR DESCRIPTION
This reverts commit 27663a119eb93e35872de4b05cf49b2e8ce6a8b5, fix https://github.com/attermann/microReticulum_Firmware/issues/86