### PR TITLE
fix: backport SX1262 PHY optimisations for RAK4631 from Meshtastic

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -831,6 +831,8 @@
       #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
       #define BLE_MANUFACTURER "RAK Wireless"
       #define BLE_MODEL "RAK4640"
+      
+      #define OCP_TUNED 0x38 // 140mA limit for SX1262 at 22dBm
 
       const int pin_btn_usr1 = 9;
 
@@ -869,6 +871,8 @@
       #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
       #define BLE_MANUFACTURER "RAK Wireless"
       #define BLE_MODEL "RAK3401"
+      
+      #define OCP_TUNED 0x38 // 140mA limit for SX1262 at 22dBm
 
       // RAK13302 SKY66122-11 FEM: +8 dBm PA gain (constant per datasheet),
       // 30 dBm (1 W) max output. Gain values from Meshtastic config.

--- a/sx126x.cpp
+++ b/sx126x.cpp
@@ -474,6 +474,7 @@ int sx126x::begin(uint32_t frequency) {
   setTxPower(2);
   enableCrc();
   writeRegister(REG_LNA_6X, 0x96); // Set LNA boost
+  writeRegister(0x0902, 0x00); // RTC STOP (Semtech Errata 15.3)
   uint8_t basebuf[2] = {0}; // Set base addresses
   executeOpcode(OP_BUFFER_BASE_ADDR_6X, basebuf, 2);
 
@@ -823,10 +824,10 @@ void sx126x::enableTCXO() {
       if (_tcxoVoltageOverride != 0xFF) {
         mode = _tcxoVoltageOverride;
       } else {
-        #if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_XIAO_S3
+        #if BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_XIAO_S3
           mode = MODE_TCXO_3_3V_6X;
-        #elif BOARD_MODEL == BOARD_RAK3401
-          // RAK13302 specifies DIO3 TCXO at 1.8V (SX126X_DIO3_TCXO_VOLTAGE 1.8)
+        #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
+          // RAK4631 and RAK13302 specify DIO3 TCXO at 1.8V
           mode = MODE_TCXO_1_8V_6X;
         #elif BOARD_MODEL == BOARD_TBEAM
           mode = MODE_TCXO_1_8V_6X;


### PR DESCRIPTION
This PR addresses several physical layer misconfigurations for the SX1262 transceiver on the RAK4631 (drawing upon proven optimisations from the Meshtastic project and RadioLib):

- TCXO Voltage: Corrects the DIO3 TCXO voltage from 3.3V to 1.8V for the RAK4631, aligning with the hardware specification to prevent frequency drift and potential component degradation.
- RTC Stop Errata (Semtech 15.3): Explicitly writes 0x00 to register 0x0902 during initialisation. This prevents the internal RTC from triggering spontaneous wakeups, avoiding silent hardware lockups.
- OCP Tuning: Increases the Over-Current Protection (OCP) limit to 140mA (0x38) for both RAK4631 and RAK3401. 

This ensures the 22dBm transmit power is not artificially clipped by the default 100mA limiter, maximising range and signal integrity.