### PR TITLE
Web console: merged/cached provisioning wire format and web persist Settings to localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Provisioning wire format** — reworked the wire protocol for lower LoRa airtime and fewer round-trips. Breaking change from the previous format:
+    - `GET_STATE` now returns `{Values, Drafts?, Hash}`; the `Draft` request flag folds drafts into the same response.
+    - `GET_STATE` supports a `PriorHash` short-circuit: clients echo the previous response's `Hash` back, and the server responds `{Unchanged: true}` when state hasn't changed.
+    - `SET_STATE` requests use a `{State: {...}, IncludeState?, ReqCompress?}` envelope. With `IncludeState: true`, the response includes `PostOpValues` / `PostOpDrafts` / `PostOpHash` — Save no longer needs a follow-up `GET_STATE`.
+    - `COMMIT` requests use a `{NamespaceFilter?, IncludeState?, ReqCompress?}` map (was a bare `[ns_ids]` array). With `IncludeState: true`, the response carries post-commit `PostOpValues` and `PostOpHash` — Commit no longer needs a follow-up refresh.
+    - `GET_CAPABILITIES` returns a namespace hierarchy map (`{NsId, NsName, NsParent, NsFieldCount, NsSchemaHash}`) instead of a bare id array; combined with `GET_SCHEMA`'s new `NamespaceFilter` support, this enables lazy per-namespace schema loading.
+- **Web console** — refactored to use the new wire protocol. Save and Commit each collapse from two transactions to one; namespace-panel refreshes cache-hit via `PriorHash` when state hasn't changed since the last poll.
+
 ## [1.86.4] - 2026-06-27
 
 ### Added

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -1172,7 +1172,7 @@ inline void kiss_write_packet() {
 
 #if defined(HAS_RNS) && defined(LORA_TRANSPORT)
   if (host_write_len > 0) {
-    TRACEF("[radio] Received %d byte packet", host_write_len);
+    printf("[radio] Received %d byte packet", host_write_len);
     // CBA send packet received over LoRa to RNS in addition to connected client
     RNS::Bytes data(pbuf, host_write_len);
     lora_interface.r_stat_rssi(last_rssi);
@@ -1658,6 +1658,7 @@ void transmit(uint16_t size) {
           LoRa->beginPacket();
           LoRa->write(header);
           written = 1;
+          printf("[radio] Sent %d byte packet (split)", written);
         }
       }
 
@@ -1674,7 +1675,7 @@ void transmit(uint16_t size) {
       }
 
       add_airtime(written);
-      TRACEF("[radio] Sent %d byte packet", written);
+      printf("[radio] Sent %d byte packet", written);
 
     } else {
       led_tx_on(); uint16_t written = 0;
@@ -1683,7 +1684,7 @@ void transmit(uint16_t size) {
       else           { LoRa->beginPacket(size); }
       for (uint16_t i=0; i < size; i++) { LoRa->write(tbuf[i]); written++; }
       LoRa->endPacket(); add_airtime(written);
-      TRACEF("[radio] Sent %d byte packet", written);
+      printf("[radio] Sent %d byte packet", written);
     }
 
   } else { kiss_indicate_error(ERROR_TXFAILED); led_indicate_error(5); }

--- a/docs/Provisioning.md
+++ b/docs/Provisioning.md
@@ -16,6 +16,11 @@ This guide walks through using the **RNode Console** (the single-page web app sh
   - [WebSocket (WiFi)](#websocket-wifi)
   - [RNS via ReticulumAPI](#rns-via-ReticulumAPI)
 - [Console tabs in detail](#console-tabs-in-detail)
+  - [Settings](#settings)
+  - [Node Status](#node-status)
+  - [Node Config](#node-config)
+  - [Transport Config](#transport-config)
+  - [Logs](#logs)
 - [Caveats and pitfalls](#caveats-and-pitfalls)
   - [RNS over LoRa](#rns-over-lora)
   - [Security and exposure](#security-and-exposure)
@@ -36,6 +41,8 @@ A node's identity in the RNS sense is a long-lived Ed25519 keypair generated on 
 ## Opening the Console
 
 The Console is a static HTML file. Open `Release/console.html` from disk (drag-and-drop into Chrome / Edge / latest Firefox), serve it from any static web server, or — when the device is in console mode — load it directly from the node's HTTP endpoint at `http://10.0.0.1/`.
+
+On launch the **Settings** tab is active — this is where connection defaults live (transport, per-transport auto-reconnect, WebSocket URL, RNS URL, default serial / Bluetooth device, RNS destination hash). Values you set there persist across page reloads in browser localStorage and pre-fill the top-bar fields at launch. On successful connect, the Console switches to **Node Status** automatically.
 
 The Console only depends on the browser's Web Serial, Web Bluetooth, and WebSocket APIs. Chrome and Chromium-derived Edge and the latest versions of Firefox are the supported browsers; Safari and older Firefox versions lack Web Serial / Web Bluetooth and can only use the WebSocket and RNS transports.
 
@@ -77,12 +84,12 @@ The RNode Console does **not** itself speak RNS — your browser can't open a Re
 1. Install and run [ReticulumAPI](https://github.com/attermann/ReticulumAPI) on your workstation. Make sure it has at least one RNS interface configured that can reach the target node (typically a `TCPClientInterface` to your local rnsd, plus whatever LoRa / packet-radio interfaces sit between you and the node).
 2. ReticulumAPI exposes a WebSocket bus (default `wss://localhost:8000/ws` — confirm the path in your ReticulumAPI install) with a generic `link.*` API. The Console uses this bus to ask ReticulumAPI to open a Link, send frames over it, and receive replies.
 3. **Obtain the destination hash of the remote node.** When a node announces, its `rnstransport.remote.management` destination shows up in Reticulum's path table. Grab the 16-byte hex hash with `rnsd` / `rnpath` / `rnstatus`, or read it off the local Console's **Transport Config → Metrics → Destinations → mgmt_destination** field.
-4. In the Console topbar, select `Transport: RNS (via ReticulumAPI)`. Fill in:
-   - **WebSocket URL** — your local ReticulumAPI endpoint (e.g. `ws://localhost:8000/ws`).
-   - **Destination hash** — the 32-hex-character hash from step 3.
-   - **Aspect** — usually `rnstransport.remote.management` (default).
-   - **authenticate** — check this to identify on the Link with ReticulumAPI's local identity. Required if the node restricts management to an allow-list.
-5. Click **Connect**. The status pill walks through the phases: *WS connecting → WS verifying → Link connecting → Finding path → Establishing link → Identifying → Connected*. This commonly takes 10–30 seconds over LoRa, much longer than the snappy Serial / BLE / WebSocket paths — the Console raises the per-request timeout when the RNS transport is in use to accommodate Resource transfers.
+4. Open the **Settings** tab → **RNS** section and set:
+   - **rnsapid URL** — your local ReticulumAPI endpoint (e.g. `ws://localhost:8000/ws`).
+   - **Identify** — check this to identify on the Link with ReticulumAPI's local identity. Required if the node restricts management to an allow-list.
+   - **Default destination hash** *(optional)* — the 32-hex-character hash from step 3; pre-fills the top-bar destination-hash field on future launches.
+5. In the Console top-bar, select `Transport: RNS`. Fill in **Destination hash** (the 32-hex-character hash from step 3, pre-filled if you set a default in Settings). The aspect is fixed to `rnstransport.remote.management` inside the transport and not surfaced in the UI.
+6. Click **Connect**. The status pill walks through the phases: *WS connecting → WS verifying → Link connecting → Finding path → Establishing link → Identifying → Connected*. This commonly takes 10–30 seconds over LoRa, much longer than the snappy Serial / BLE / WebSocket paths — the Console raises the per-request timeout when the RNS transport is in use to accommodate Resource transfers.
 
 > **Note on ReticulumAPI.** ReticulumAPI is used here as a thin RNS-to-WebSocket bridge: it gives the browser something to talk to that knows how to open Reticulum Links. Any future tool implementing the same `link.*` WebSocket protocol could be substituted. The Console caches its Link in ReticulumAPI, but a clean disconnect (`Disconnect` button, tab close, refresh) tells ReticulumAPI to evict the cache so the next session opens a fresh Link.
 
@@ -147,9 +154,25 @@ Things that *don't* work over RNS:
 
 ## Console tabs in detail
 
+### Settings
+
+Always visible and always enabled. It's the pre-connect landing tab: connection defaults and less-frequently-changed transport fields live here. All values persist in browser localStorage under the key `rnode.console.settings.v1` and pre-fill the top-bar at page load. Edits made in the top-bar during a session are **not** written back to Settings — Settings is user-managed only.
+
+Sections:
+
+- **General** — Default transport (Serial / Bluetooth / WebSocket / RNS).
+- **Serial** — Default serial device (dropdown of previously-authorized ports via `navigator.serial.getPorts()`; **Request another…** button prompts the browser to authorize a new device) and per-transport auto-reconnect default. If a default is set and still authorized, **Connect** skips the browser picker.
+- **Bluetooth** — Default Bluetooth device (dropdown via `navigator.bluetooth.getDevices()`, which requires enabling `chrome://flags/#enable-web-bluetooth-new-permissions-backend`; without that flag the dropdown is hidden and Connect always shows the browser picker) and per-transport auto-reconnect default.
+- **WebSocket** — Default URL and per-transport auto-reconnect default.
+- **RNS** — Live rnsapid URL and Identify checkbox (moved out of the top-bar; edited here exclusively), default destination hash (pre-fills the top-bar field at launch), and per-transport auto-reconnect default.
+
+The top-bar's shared **auto-reconnect** checkbox is re-seeded from the selected transport's per-transport Settings default whenever you change the transport dropdown. Top-bar toggles are session-only.
+
+On successful connect, the Console switches to **Node Status** immediately (before device info / schema fetches complete) so the tab change confirms the connection.
+
 ### Node Status
 
-Always available. Shows:
+Visible always, enabled when connected. Shows:
 
 - **Device** — firmware version, schema version, board / platform / MCU, "needs reboot" flag.
 - **Radio link** — last RSSI, last SNR, current RSSI, noise floor, interference RSSI.

--- a/webconsole/index.html
+++ b/webconsole/index.html
@@ -585,13 +585,17 @@ class KissDecoder {
 
 // ===== Transports =====
 class SerialTransport {
-  constructor(){
+  constructor(preselected){
     this.port=null;
     this.reader=null;
     this.writer=null;
     this.onBytes=()=>{};
     this.onStatus=()=>{};
     this._abort=false;
+    // Optional pre-authorized SerialPort (resolved by doConnect via
+    // navigator.serial.getPorts() before construction). If set, connect()
+    // uses it directly and skips the browser picker.
+    this._preselected = preselected || null;
     // ────────────────────────────────────────────────────────────────────
     // TEMPORARY WORKAROUND for a Chrome Web Serial quirk:
     // After a physical USB disconnect/reconnect cycle (e.g. device reset
@@ -706,7 +710,8 @@ class SerialTransport {
   async connect(){
     this.onStatus({state:'connecting'});
     try {
-      this.port = await navigator.serial.requestPort();
+      if (this._preselected) { this.port = this._preselected; this._preselected = null; }
+      else                   { this.port = await navigator.serial.requestPort(); }
       this._installNavSerialListeners();
       await this._open();
     } catch (e) {
@@ -780,12 +785,20 @@ const NUS_SERVICE = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
 const NUS_RX_CHAR = '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
 const NUS_TX_CHAR = '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
 class BLETransport {
-  constructor(){ this.device=null; this.rx=null; this.tx=null; this.onBytes=()=>{}; this.onStatus=()=>{}; this._writeNoResp=true; this._gattHandler=null; this._notifyHandler=null; }
+  constructor(preselected){
+    this.device=null; this.rx=null; this.tx=null; this.onBytes=()=>{}; this.onStatus=()=>{};
+    this._writeNoResp=true; this._gattHandler=null; this._notifyHandler=null;
+    // Optional pre-authorized BluetoothDevice (resolved by doConnect via
+    // navigator.bluetooth.getDevices() before construction). If set,
+    // connect() uses it directly and skips the browser picker.
+    this._preselected = preselected || null;
+  }
   static available(){ return !!navigator.bluetooth; }
   async connect(){
     this.onStatus({state:'connecting'});
     try {
-      this.device = await navigator.bluetooth.requestDevice({ filters: [{ services: [NUS_SERVICE] }] });
+      if (this._preselected) { this.device = this._preselected; this._preselected = null; }
+      else                   { this.device = await navigator.bluetooth.requestDevice({ filters: [{ services: [NUS_SERVICE] }] }); }
       this._gattHandler = () => this.onStatus({state:'closed'});
       this.device.addEventListener('gattserverdisconnected', this._gattHandler);
       await this._attach();
@@ -2313,6 +2326,31 @@ function el(tag, attrs, children){
   return e;
 }
 
+// ===== Settings persistence =====
+// Single JSON blob under SETTINGS_KEY holds user-facing defaults (loaded at
+// launch to pre-fill banner fields) plus the RNS URL / identify flag which the
+// Settings tab now owns exclusively. All access swallows exceptions so a
+// disabled or full localStorage silently falls back to in-memory state.
+const SETTINGS_KEY = 'rnode.console.settings.v1';
+const settingsStore = {
+  load(){
+    try { const raw = window.localStorage && localStorage.getItem(SETTINGS_KEY); return raw ? JSON.parse(raw) : {}; }
+    catch(_) { return {}; }
+  },
+  save(patch){
+    try {
+      const cur = settingsStore.load();
+      const next = { ...cur, ...patch,
+        defaults:      { ...(cur.defaults||{}),      ...(patch.defaults||{}) },
+        autoReconnect: { ...(cur.autoReconnect||{}), ...(patch.autoReconnect||{}) } };
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify(next));
+    } catch(_) { /* quota / disabled — silent fallback */ }
+  },
+};
+// Stable identifier for a SerialPort based on getInfo(). Matches the fallback
+// USB fields used by _portsMatch() so a stored key survives across sessions.
+function portKey(info){ return `${(info.usbVendorId||0).toString(16)}:${(info.usbProductId||0).toString(16)}:${info.usbSerialNumber||''}`; }
+
 // ===== State =====
 const state = {
   transportName: observable('serial'),
@@ -2320,10 +2358,22 @@ const state = {
   rnsUrl: observable('wss://localhost:8000/ws'),
   rnsDestHash: observable(''),
   rnsAutoIdentify: observable(true),
+  // Persistent defaults edited only via the Settings tab. Live state above is
+  // pre-filled from these at launch, then decoupled — in-session banner edits
+  // do not write back.
+  defaultTransport: observable('serial'),
+  defaultSerialPortKey: observable(null),     // "vid:pid:serial" or null
+  defaultBluetoothDeviceId: observable(null), // navigator.bluetooth device.id or null
+  defaultWsUrl: observable('ws://localhost:8080'),
+  defaultRnsDestHash: observable(''),
+  autoReconnectSerial: observable(true),
+  autoReconnectBle:    observable(true),
+  autoReconnectWs:     observable(true),
+  autoReconnectRns:    observable(true),
   conn: observable({ state: 'idle' }),
   info: observable(null),
   schema: observable(null),
-  activeTab: observable('status'),         // 'status' | 'nodeconfig' | 'config' | 'logs'
+  activeTab: observable('settings'),       // 'settings' | 'status' | 'nodeconfig' | 'config' | 'logs'
   activeNsTab: observable(null),           // ns_id within Configuration tab
   nsState: observable({}),                 // { nsId: { committed:{fid:val}, draft:{fid:val} } }
   nsLoaded: observable({}),                // { nsId: true }
@@ -2379,9 +2429,42 @@ let lastTransportName = null;
 // Single in-flight reconnect token. Bumping it cancels the previous attempt.
 let reconnectToken = 0;
 
-function createTransport(name){
-  if (name === 'serial') return new SerialTransport();
-  if (name === 'ble') return new BLETransport();
+// Launch-time preload from localStorage. URL / hash defaults populate BOTH the
+// live observable (so the banner shows them) AND the default* observable (so
+// the Settings tab shows them). After this, live values are edited in the
+// banner and defaults are edited in Settings — they do not sync during the
+// session. The banner's shared auto-reconnect checkbox is seeded from the
+// currently-selected transport's per-transport default.
+(function preloadSettings(){
+  const s = settingsStore.load();
+  if (s.defaultTransport) { state.defaultTransport.set(s.defaultTransport); state.transportName.set(s.defaultTransport); }
+  if (s.defaultSerialPortKey) state.defaultSerialPortKey.set(s.defaultSerialPortKey);
+  if (s.defaultBluetoothDeviceId) state.defaultBluetoothDeviceId.set(s.defaultBluetoothDeviceId);
+  const d = s.defaults || {};
+  if (typeof d.wsUrl === 'string')            { state.defaultWsUrl.set(d.wsUrl); state.wsUrl.set(d.wsUrl); }
+  if (typeof d.rnsUrl === 'string')           state.rnsUrl.set(d.rnsUrl);
+  if (typeof d.rnsDestHash === 'string')      { state.defaultRnsDestHash.set(d.rnsDestHash); state.rnsDestHash.set(d.rnsDestHash); }
+  if (typeof d.rnsAutoIdentify === 'boolean') state.rnsAutoIdentify.set(d.rnsAutoIdentify);
+  const ar = s.autoReconnect || {};
+  if (typeof ar.serial === 'boolean') state.autoReconnectSerial.set(ar.serial);
+  if (typeof ar.ble    === 'boolean') state.autoReconnectBle.set(ar.ble);
+  if (typeof ar.ws     === 'boolean') state.autoReconnectWs.set(ar.ws);
+  if (typeof ar.rns    === 'boolean') state.autoReconnectRns.set(ar.rns);
+  state.autoReconnect.set(perTransportAutoReconnect(state.transportName.get()));
+})();
+function perTransportAutoReconnect(tn){
+  const map = { serial: state.autoReconnectSerial, ble: state.autoReconnectBle, ws: state.autoReconnectWs, rns: state.autoReconnectRns };
+  return (map[tn] || state.autoReconnect).get();
+}
+// URLs / hash defaults are launch-only, but auto-reconnect is a per-transport
+// policy: switching transports SHOULD swap the banner checkbox to that
+// transport's stored default. Registered after preloadSettings() so its
+// state.transportName.set() call doesn't trigger this handler prematurely.
+state.transportName.subscribe((tn) => state.autoReconnect.set(perTransportAutoReconnect(tn)));
+
+function createTransport(name, preselected){
+  if (name === 'serial') return new SerialTransport(preselected);
+  if (name === 'ble') return new BLETransport(preselected);
   if (name === 'ws') return new WebSocketTransport();
   if (name === 'rns') return new RnsTransport();
   throw new Error('unknown transport ' + name);
@@ -2460,7 +2543,25 @@ async function doConnect(){
   const name = state.transportName.get();
   lastTransportName = name;
   try {
-    transport = createTransport(name);
+    // Resolve the Settings default device (if any) to a pre-authorized handle
+    // so we can skip the browser picker. If the stored default is no longer
+    // authorized, pre stays null and the transport falls back to the picker;
+    // we deliberately do NOT clear the stored key — the device may reappear.
+    let pre = null;
+    if (name === 'serial' && navigator.serial && state.defaultSerialPortKey.get()) {
+      try {
+        const key = state.defaultSerialPortKey.get();
+        const ports = await navigator.serial.getPorts();
+        pre = ports.find(p => portKey(p.getInfo()) === key) || null;
+      } catch (_) { pre = null; }
+    } else if (name === 'ble' && navigator.bluetooth && typeof navigator.bluetooth.getDevices === 'function' && state.defaultBluetoothDeviceId.get()) {
+      try {
+        const id = state.defaultBluetoothDeviceId.get();
+        const devs = await navigator.bluetooth.getDevices();
+        pre = devs.find(d => d.id === id) || null;
+      } catch (_) { pre = null; }
+    }
+    transport = createTransport(name, pre);
     transport.onStatus = onTransportStatus;
     client = new ProvisioningClient(transport);
     wireClient(client);
@@ -2478,6 +2579,11 @@ async function doConnect(){
 }
 
 async function afterConnect(){
+  // Switch to Node Status immediately so the tab change confirms the
+  // connection to the user; the tab body handles its own "waiting for status
+  // frames…" placeholder while the async fetches below complete. Guarded so
+  // we don't yank users off a tab they navigated to intentionally.
+  if (state.activeTab.get() === 'settings') state.activeTab.set('status');
   try { state.info.set(await client.getInfo()); } catch (e) { console.error('getInfo:', e); showToast('Failed to fetch device info: ' + e.message, 'err'); }
   try {
     const schema = await client.resolveSchema(state.info.get());
@@ -3116,23 +3222,14 @@ function buildTopBar(){
   // Mount once; toggle visibility in update() so typing doesn't detach the
   // focused input (which would drop focus on every keystroke).
   wsHost.appendChild(wsInput);
-  // RNS-over-rnsapid config: WS URL + destination hash + auto-identify. The
-  // provisioning aspect is fixed (rnstransport.remote.management) and
-  // hard-coded inside RnsTransport, so it's not surfaced in the UI.
+  // RNS destination hash lives here for quick per-session edits. The rnsapid
+  // WS URL and 'identify' flag have moved to the Settings tab (RNS section) —
+  // doConnect() still reads them from state.rnsUrl / state.rnsAutoIdentify.
   const rnsHost = el('span', { style: { display: 'inline-flex', gap: '4px', alignItems: 'center' } });
-  const rnsUrlInput = el('input', { type: 'text', placeholder: 'ws://host:port/ws', style: { width: '200px' }, title: 'rnsapid WebSocket URL (anonymous session; auth disabled)' });
-  rnsUrlInput.value = state.rnsUrl.get();
-  rnsUrlInput.oninput = (e) => state.rnsUrl.set(e.target.value);
   const rnsHashInput = el('input', { type: 'text', placeholder: 'destination hash (32 hex)', style: { width: '260px', fontFamily: 'monospace' }, maxlength: '32', title: 'Remote node destination hash (32 hex chars)' });
   rnsHashInput.value = state.rnsDestHash.get();
   rnsHashInput.oninput = (e) => state.rnsDestHash.set(e.target.value.trim());
-  const rnsIdentCb = el('input', { type: 'checkbox' });
-  rnsIdentCb.checked = state.rnsAutoIdentify.get();
-  rnsIdentCb.onchange = (e) => state.rnsAutoIdentify.set(e.target.checked);
-  const rnsIdentLabel = el('label', { style: { display: 'inline-flex', alignItems: 'center', gap: '4px', cursor: 'pointer', color: 'var(--muted)' }, title: 'Send local identity on link establishment (auto_identify=true; required by /provision ALLOW_LIST)' }, [rnsIdentCb, 'identify']);
-  rnsHost.appendChild(rnsUrlInput);
   rnsHost.appendChild(rnsHashInput);
-  rnsHost.appendChild(rnsIdentLabel);
   const connectBtn = el('button');
   const disconnectBtn = el('button', null, 'Disconnect');
   const autoCheckbox = el('input', { type: 'checkbox' });
@@ -3140,7 +3237,7 @@ function buildTopBar(){
   autoCheckbox.onchange = (e) => state.autoReconnect.set(e.target.checked);
   const autoLabel = el('label', { style: { display: 'inline-flex', alignItems: 'center', gap: '4px', cursor: 'pointer', color: 'var(--muted)' }, title: 'Reconnect automatically after a reboot to capture early boot logs' }, [autoCheckbox, 'auto-reconnect']);
   const pill = el('span', { class: 'pill' });
-  const opts = [['serial','Serial'], ['ble','Bluetooth'], ['ws','WebSocket'], ['rns','RNS (via rnsapid)']];
+  const opts = [['serial','Serial'], ['ble','Bluetooth'], ['ws','WebSocket'], ['rns','RNS']];
   for (const [v, lbl] of opts) sel.appendChild(el('option', { value: v }, lbl));
   sel.value = state.transportName.get();
   sel.onchange = (e) => state.transportName.set(e.target.value);
@@ -3153,9 +3250,9 @@ function buildTopBar(){
   root.appendChild(sel);
   root.appendChild(wsHost);
   root.appendChild(rnsHost);
+  root.appendChild(autoLabel);
   root.appendChild(connectBtn);
   root.appendChild(disconnectBtn);
-  root.appendChild(autoLabel);
   root.appendChild(el('span', { class: 'spacer' }));
   root.appendChild(pill);
 
@@ -3180,12 +3277,8 @@ function buildTopBar(){
     const showRns = (tname === 'rns');
     rnsHost.style.display = showRns ? '' : 'none';
     if (showRns) {
-      if (document.activeElement !== rnsUrlInput && rnsUrlInput.value !== state.rnsUrl.get()) rnsUrlInput.value = state.rnsUrl.get();
       if (document.activeElement !== rnsHashInput && rnsHashInput.value !== state.rnsDestHash.get()) rnsHashInput.value = state.rnsDestHash.get();
-      if (rnsIdentCb.checked !== state.rnsAutoIdentify.get()) rnsIdentCb.checked = state.rnsAutoIdentify.get();
-      rnsUrlInput.disabled = connecting || connected || reconnecting;
       rnsHashInput.disabled = connecting || connected || reconnecting;
-      rnsIdentCb.disabled = connecting || connected || reconnecting;
     }
     connectBtn.disabled = connecting || connected || reconnecting;
     connectBtn.textContent = connecting ? 'Connecting…' : 'Connect';
@@ -3219,9 +3312,7 @@ function buildTopBar(){
   state.conn.subscribe(update);
   state.transportName.subscribe(update);
   state.wsUrl.subscribe(update);
-  state.rnsUrl.subscribe(update);
   state.rnsDestHash.subscribe(update);
-  state.rnsAutoIdentify.subscribe(update);
 
   state.autoReconnect.subscribe(update);
   state.reconnecting.subscribe(update);
@@ -3232,8 +3323,11 @@ slots.topbar.appendChild(buildTopBar());
 // ----- Tab bar (in place) -----
 function buildTabBar(){
   const root = el('div', { class: 'tabbar' });
-  // Info merged into Node Status; that's now the always-available landing tab.
+  // Settings is the always-available pre-connect landing tab (defaults surface
+  // here for review before connecting). Node Status remains the post-connect
+  // landing tab (afterConnect() auto-switches to it).
   const tabs = [
+    { id: 'settings', label: 'Settings' },
     { id: 'status', label: 'Node Status' },
     { id: 'nodeconfig', label: 'Node Config' },
     { id: 'config', label: 'Transport Config' },
@@ -3261,9 +3355,10 @@ function buildTabBar(){
     // Treat "reconnecting" as not-yet-connected so per-tab actions don't fire
     // against a transport that's still being re-established.
     const connected = state.conn.get().state === 'connected' && !state.reconnecting.get();
-    // Capability-gated visibility: every tab other than Node Status only
+    // Capability-gated visibility: every tab other than Settings only
     // surfaces once we've positively confirmed the active transport supports
-    // it. While disconnected (or reconnecting), only Node Status shows.
+    // it. While disconnected (or reconnecting), only Settings is enabled —
+    // Node Status remains visible but disabled so its label acts as a hint.
     //   - Node Config (legacy KISS opcodes): requires legacySupported === true
     //     (CMD_BOARD probe succeeded). Starts null and the probe takes up to
     //     1500ms, during which we keep the tab hidden — a brief delay is
@@ -3279,15 +3374,16 @@ function buildTabBar(){
     for (const t of tabs) {
       const b = buttons[t.id];
       b.classList.toggle('active', active === t.id);
-      b.disabled = !connected && t.id !== 'status';
+      b.disabled = !connected && t.id !== 'settings';
       if (t.id === 'config')     b.style.display = showCfg  ? '' : 'none';
       if (t.id === 'nodeconfig') b.style.display = showNcfg ? '' : 'none';
       if (t.id === 'logs')       b.style.display = showLogs ? '' : 'none';
     }
     // Redirect away from any hidden tab so the user isn't on an invisible body.
-    if (!showCfg  && active === 'config')     state.activeTab.set('status');
-    if (!showNcfg && active === 'nodeconfig') state.activeTab.set('status');
-    if (!showLogs && active === 'logs')       state.activeTab.set('status');
+    // Settings is always visible so no redirect from it is ever needed.
+    if (!showCfg  && active === 'config')     state.activeTab.set('settings');
+    if (!showNcfg && active === 'nodeconfig') state.activeTab.set('settings');
+    if (!showLogs && active === 'logs')       state.activeTab.set('settings');
   }
   update();
   state.activeTab.subscribe(update);
@@ -3301,6 +3397,181 @@ function buildTabBar(){
 slots.tabbar.appendChild(buildTabBar());
 
 // ----- Tab bodies -----
+
+function buildSettingsTab(){
+  const root = el('div', { class: 'tab-body' });
+  root.appendChild(el('p', { style: { color: 'var(--muted)', margin: '0 0 12px' } },
+    'Defaults are pre-loaded into the top-bar fields at page load. Edits here persist in browser localStorage; edits in the top bar are session-only.'));
+
+  // Section + row helpers mirror the Status tab's visual language.
+  function row(label, control) {
+    return el('tr', null, [el('td', null, label), el('td', null, control)]);
+  }
+  function section(title, rows) {
+    return el('div', { class: 'status-sec' }, [el('h3', null, title), el('table', { class: 'kv' }, rows.filter(x => x != null))]);
+  }
+  // Two-way binding between a form control and an observable, with
+  // write-through to settingsStore on user edits. Reads clone the current
+  // value on subscribe; writes call persist(v) to build a store patch.
+  function bindSetting(input, obs, kind, persist) {
+    const isCheck = kind === 'checked';
+    const write = (v) => { if (isCheck) input.checked = !!v; else input.value = v == null ? '' : v; };
+    write(obs.get());
+    const evt = (isCheck || input.tagName === 'SELECT') ? 'change' : 'input';
+    input.addEventListener(evt, () => {
+      const v = isCheck ? input.checked : input.value;
+      obs.set(v);
+      settingsStore.save(persist(v));
+    });
+    bodyCleanups.push(obs.subscribe(v => { if (document.activeElement !== input) write(v); }));
+  }
+
+  // ---- General ----
+  const genSelect = el('select');
+  for (const [v, lbl] of [['serial','Serial'],['ble','Bluetooth'],['ws','WebSocket'],['rns','RNS']]) {
+    genSelect.appendChild(el('option', { value: v }, lbl));
+  }
+  bindSetting(genSelect, state.defaultTransport, 'value', v => ({ defaultTransport: v }));
+  root.appendChild(section('General', [
+    row('Default transport', genSelect),
+  ]));
+
+  // ---- Serial ----
+  const serialDefault = el('em', { style: { color: 'var(--muted)' } }, 'Web Serial not supported in this browser.');
+  const serialAutoCb = el('input', { type: 'checkbox' });
+  const serialRows = [];
+  if (navigator.serial) {
+    const serialSelect = el('select', { style: { minWidth: '260px' }, title: 'Authorized ports appear here. Choose one as the default so Connect skips the browser picker. Not remembered as a default when Connect prompts the picker.' });
+    const noneOpt = el('option', { value: '' }, '— No default (prompt on Connect) —');
+    serialSelect.appendChild(noneOpt);
+    // Selection wires to state.defaultSerialPortKey + persistence directly
+    // (bindSetting can't handle the async-populated option list cleanly).
+    const applySelection = () => {
+      const v = serialSelect.value || null;
+      state.defaultSerialPortKey.set(v);
+      settingsStore.save({ defaultSerialPortKey: v });
+    };
+    serialSelect.addEventListener('change', applySelection);
+    const requestBtn = el('button', { onclick: async () => {
+      try {
+        const port = await navigator.serial.requestPort();
+        const key = portKey(port.getInfo());
+        // Rebuild the option list to pick up the newly-authorized port.
+        await populateSerial(serialSelect, key);
+        state.defaultSerialPortKey.set(key);
+        settingsStore.save({ defaultSerialPortKey: key });
+      } catch (_) { /* user cancelled */ }
+    }, title: 'Prompt the browser to authorize a new serial device and set it as the default.' }, 'Request another…');
+    // Kick off async populate; keep default option first, then append authorized ports.
+    populateSerial(serialSelect, state.defaultSerialPortKey.get());
+    bindSetting(serialAutoCb, state.autoReconnectSerial, 'checked', v => ({ autoReconnect: { serial: v } }));
+    serialRows.push(row('Default device', el('span', { style: { display: 'inline-flex', gap: '8px', alignItems: 'center' } }, [serialSelect, requestBtn])));
+    serialRows.push(row('Auto-reconnect', serialAutoCb));
+  } else {
+    serialRows.push(row('Default device', serialDefault));
+  }
+  root.appendChild(section('Serial', serialRows));
+
+  // ---- Bluetooth ----
+  const bleRows = [];
+  const bleAutoCb = el('input', { type: 'checkbox' });
+  if (navigator.bluetooth) {
+    const bleSelect = el('select', { style: { minWidth: '260px' } });
+    bleSelect.appendChild(el('option', { value: '' }, '— No default (prompt on Connect) —'));
+    if (typeof navigator.bluetooth.getDevices === 'function') {
+      bleSelect.addEventListener('change', () => {
+        const v = bleSelect.value || null;
+        state.defaultBluetoothDeviceId.set(v);
+        settingsStore.save({ defaultBluetoothDeviceId: v });
+      });
+      populateBluetooth(bleSelect, state.defaultBluetoothDeviceId.get());
+      bleRows.push(row('Default device', bleSelect));
+    } else {
+      bleSelect.disabled = true;
+      bleRows.push(row('Default device', el('span', null, [
+        bleSelect,
+        el('div', { style: { marginTop: '4px', color: 'var(--muted)', fontSize: '11px', maxWidth: '520px' } },
+          'Enumerating authorized Bluetooth devices requires enabling chrome://flags/#enable-web-bluetooth-new-permissions-backend. Connect will show the picker each time.')
+      ])));
+    }
+    bindSetting(bleAutoCb, state.autoReconnectBle, 'checked', v => ({ autoReconnect: { ble: v } }));
+    bleRows.push(row('Auto-reconnect', bleAutoCb));
+  } else {
+    bleRows.push(row('Default device', el('em', { style: { color: 'var(--muted)' } }, 'Web Bluetooth not supported in this browser.')));
+  }
+  root.appendChild(section('Bluetooth', bleRows));
+
+  // ---- WebSocket ----
+  const wsInput = el('input', { type: 'text', placeholder: 'ws://host:port', style: { width: '280px' } });
+  bindSetting(wsInput, state.defaultWsUrl, 'value', v => ({ defaults: { wsUrl: v } }));
+  const wsAutoCb = el('input', { type: 'checkbox' });
+  bindSetting(wsAutoCb, state.autoReconnectWs, 'checked', v => ({ autoReconnect: { ws: v } }));
+  root.appendChild(section('WebSocket', [
+    row('Default URL', wsInput),
+    row('Auto-reconnect', wsAutoCb),
+  ]));
+
+  // ---- RNS ----
+  // rnsapid URL + identify are LIVE values (moved from banner; doConnect
+  // reads them from state.rnsUrl / state.rnsAutoIdentify). Destination hash
+  // has a separate default field — banner still holds the live hash.
+  const rnsUrlInput = el('input', { type: 'text', placeholder: 'ws://host:port/ws', style: { width: '280px' }, title: 'rnsapid WebSocket URL (anonymous session; auth disabled)' });
+  bindSetting(rnsUrlInput, state.rnsUrl, 'value', v => ({ defaults: { rnsUrl: v } }));
+  const rnsIdentCb = el('input', { type: 'checkbox', title: 'Send local identity on link establishment (auto_identify=true; required by /provision ALLOW_LIST)' });
+  bindSetting(rnsIdentCb, state.rnsAutoIdentify, 'checked', v => ({ defaults: { rnsAutoIdentify: v } }));
+  const rnsHashInput = el('input', { type: 'text', placeholder: 'destination hash (32 hex)', style: { width: '280px', fontFamily: 'monospace' }, maxlength: '32', title: 'Default remote node destination hash (pre-fills the top-bar field at launch)' });
+  bindSetting(rnsHashInput, state.defaultRnsDestHash, 'value', v => ({ defaults: { rnsDestHash: v } }));
+  const rnsAutoCb = el('input', { type: 'checkbox' });
+  bindSetting(rnsAutoCb, state.autoReconnectRns, 'checked', v => ({ autoReconnect: { rns: v } }));
+  root.appendChild(section('RNS', [
+    row('rnsapid URL', rnsUrlInput),
+    row('Identify', rnsIdentCb),
+    row('Default destination hash', rnsHashInput),
+    row('Auto-reconnect', rnsAutoCb),
+  ]));
+
+  return root;
+}
+
+// Rebuilds the option list of a serial-port <select> from
+// navigator.serial.getPorts() and restores selectedKey if still authorized.
+// Preserves the placeholder option at index 0.
+async function populateSerial(select, selectedKey){
+  try {
+    const ports = await navigator.serial.getPorts();
+    while (select.options.length > 1) select.remove(1);
+    for (const p of ports) {
+      const info = p.getInfo();
+      const key = portKey(info);
+      const label = `USB ${info.usbVendorId?.toString(16).padStart(4,'0') || '????'}:${info.usbProductId?.toString(16).padStart(4,'0') || '????'}` +
+                    (info.usbSerialNumber ? ` (${info.usbSerialNumber})` : '');
+      select.appendChild(el('option', { value: key }, label));
+    }
+    if (selectedKey && Array.from(select.options).some(o => o.value === selectedKey)) {
+      select.value = selectedKey;
+    } else {
+      select.value = '';
+    }
+  } catch (_) { /* getPorts unavailable — leave placeholder */ }
+}
+
+// Same, but for BLE devices via navigator.bluetooth.getDevices() (behind a
+// Chrome flag). Caller must have already feature-detected getDevices.
+async function populateBluetooth(select, selectedId){
+  try {
+    const devs = await navigator.bluetooth.getDevices();
+    while (select.options.length > 1) select.remove(1);
+    for (const d of devs) {
+      const label = d.name ? `${d.name} (${d.id.slice(0, 6)}…)` : d.id;
+      select.appendChild(el('option', { value: d.id }, label));
+    }
+    if (selectedId && Array.from(select.options).some(o => o.value === selectedId)) {
+      select.value = selectedId;
+    } else {
+      select.value = '';
+    }
+  } catch (_) { /* leave placeholder */ }
+}
 
 function buildStatusTab(){
   const root = el('div', { class: 'tab-body' });
@@ -4718,7 +4989,8 @@ function buildLogsTab(){
 function updateBody(){
   const t = state.activeTab.get();
   if (bodyKey === t) return;
-  if (t === 'status') setBody('status', buildStatusTab);
+  if (t === 'settings') setBody('settings', buildSettingsTab);
+  else if (t === 'status') setBody('status', buildStatusTab);
   else if (t === 'nodeconfig') setBody('nodeconfig', buildNodeConfigTab);
   else if (t === 'config') setBody('config', buildConfigTab);
   else if (t === 'logs') setBody('logs', buildLogsTab);

--- a/webconsole/index.html
+++ b/webconsole/index.html
@@ -178,12 +178,17 @@ const CMD_LOG=0x80, CMD_PROVISION_REQ=0x86, CMD_PROVISION_RSP=0x87;
 const CMD_RESET=0x55, CMD_RESET_BYTE=0xF8;
 const STAT_CMD_RANGE = [0x21, 0x29];
 
-// Optional schema baked in at packaging time. When BUNDLED_SCHEMA is non-null
-// and its hash/version match the device's GetInfo response, the web console
-// uses it directly and skips the GetSchema round-trip entirely — important
-// on LoRa where a full schema fetch is ~3 KB of airtime. The placeholder is
-// replaced by webconsole/package.sh from a build-time schema dump. Shape:
-//   { version: <int>, hash: <uint32>, schemaJson: "<serialised schema>" }
+// Optional schema baked in at packaging time. When BUNDLED_SCHEMA is non-null,
+// resolveSchema consults it per-namespace: for each entry whose (id, schemaHash)
+// pair matches what GetCapabilities reports, the bundled schemaJson is used
+// directly and the network fetch is skipped for that namespace — important on
+// LoRa where each unused namespace saves hundreds of bytes of airtime. The
+// placeholder is replaced by webconsole/package.sh from a build-time schema
+// dump. Shape:
+//   { namespaces: [
+//       { id: <nsId>, schemaHash: <uint32>, schemaJson: "<serialised ns>" },
+//       ...
+//     ] }
 const BUNDLED_SCHEMA = null;
 
 const OP = { GetSchema:1, GetInfo:2, GetCapabilities:3, GetState:4, SetState:5, Commit:6, Discard:7, FactoryReset:8, Reboot:9, Ack:100, Error:101 };
@@ -213,7 +218,27 @@ const COMPRESSIBLE_OPS = new Set([
   OP.GetSchema, OP.GetInfo, OP.GetCapabilities, OP.GetState,
   OP.FactoryReset, OP.Reboot,
 ]);
-const GK = { NamespaceFilter:1, Pending:2 };
+// GetState / SetState request keys. NamespaceFilter scopes the fetch (GetState)
+// or is currently unused (SetState). Draft=true (GetState) asks the server to
+// include drafts alongside working. State (SetState) wraps the {ns:{fid:value}}
+// write map. PriorHash carries a client-cached CRC32 for GetState's
+// short-circuit.
+const GK  = { NamespaceFilter:1, Draft:2, State:3, PriorHash:4 };
+// GetState response body keys. Values holds the working set; Drafts (when
+// present) holds the sparse per-namespace draft map. Unchanged is a
+// single-entry cache-hit body.
+const GSK = { Values:1, Drafts:2, Hash:3, Unchanged:4 };
+// Per-namespace entry keys in the GetCapabilities response map array.
+const NSK = { NsId:1, NsName:2, NsParent:4, NsFieldCount:5, NsSchemaHash:6 };
+// Commit / SetState shared request options (both use `IncludeState` in the
+// request envelope). Numerically the same slot on the wire; one JS constant.
+const CmK = { IncludeState:5 };
+// Post-op response body keys — returned by Commit and SetState when the
+// request set IncludeState=true. Slots 4/5/6 avoid collision with Applied(1),
+// NeedsReboot/DraftHasReboot(2), and FieldErrors(3) in the enclosing body.
+// Commit only emits Values+Hash (drafts are cleared); SetState emits
+// Values+Drafts+Hash (drafts persist through SetState).
+const POK = { Values:4, Drafts:5, Hash:6 };
 const SK = { Applied:1, DraftHasReboot:2, FieldErrors:3 };
 const CK = { Applied:1, NeedsReboot:2 };
 const EK = { Code:1, Message:2, Namespace:3, Field:4 };
@@ -1343,12 +1368,12 @@ class RnsTransport {
 }
 
 // ===== Schema cache helpers =====
-// Schemas are content-addressed by the firmware's CRC32 hash (info.schemaHash),
-// so two devices reporting the same hash share the same cached entry. We cap
-// the total number of cached schemas at SCHEMA_CACHE_MAX to bound storage
-// growth as a user connects to many devices over time.
-const SCHEMA_CACHE_PREFIX = 'mrf_schema_v';
-const SCHEMA_CACHE_MAX    = 5;
+// Per-namespace schema cache. Each namespace's schema entry is content-
+// addressed by the firmware's per-namespace CRC32 (surfaced via GetCapabilities
+// as NsSchemaHash). Entries live at `mrf_schema_ns${nsId}_${hashHex}`. Stale
+// entries from prior firmware versions linger harmlessly — per-namespace
+// blobs are small and localStorage quota is generous.
+const NS_SCHEMA_CACHE_PREFIX = 'mrf_schema_ns';
 
 // Convert Uint8Array (bytes-typed defaults) to a JSON-safe tagged form. Most
 // schema fields are plain primitives, so this is rarely needed in practice.
@@ -1375,23 +1400,23 @@ function _schemaSerialize(schema){
 function _schemaDeserialize(str){
   return JSON.parse(str, _schemaJsonReviver);
 }
-// Evict the oldest entries to keep cache size bounded. Called before writing
-// a new key; the `keepKey` arg ensures we don't evict the entry we're about
-// to write if it already exists (LRU-bump semantics).
-function _schemaCachePrune(keepKey){
-  if (!window.localStorage) return;
-  const keys = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const k = localStorage.key(i);
-    if (k && k.startsWith(SCHEMA_CACHE_PREFIX) && k !== keepKey) keys.push(k);
+function _nsSchemaCacheKey(nsId, hash){
+  const h = (Number(hash) >>> 0).toString(16).padStart(8, '0');
+  return `${NS_SCHEMA_CACHE_PREFIX}${Number(nsId)}_${h}`;
+}
+// Flatten BUNDLED_SCHEMA (if any) into a lookup keyed by `${nsId}_${hashHex}`.
+// Returns null when no bundle is configured or it has no valid entries, so
+// the resolveSchema path can short-circuit past bundle lookup with a single
+// truthy check.
+function _bundledNsByHash(){
+  if (!BUNDLED_SCHEMA || !Array.isArray(BUNDLED_SCHEMA.namespaces)) return null;
+  const m = new Map();
+  for (const ns of BUNDLED_SCHEMA.namespaces) {
+    if (!ns || ns.id == null || ns.schemaHash == null || typeof ns.schemaJson !== 'string') continue;
+    const h = (Number(ns.schemaHash) >>> 0).toString(16).padStart(8, '0');
+    m.set(`${Number(ns.id)}_${h}`, ns.schemaJson);
   }
-  // localStorage doesn't expose write order, so eviction is approximate —
-  // we drop in iteration order until under the cap. Good enough for an
-  // O(<=5) cache that's only churned when a user touches many devices.
-  while (keys.length >= SCHEMA_CACHE_MAX) {
-    const victim = keys.shift();
-    try { localStorage.removeItem(victim); } catch(_) {}
-  }
+  return m.size ? m : null;
 }
 
 // ===== heatshrink decoder =====
@@ -1474,6 +1499,31 @@ class ProvisioningClient {
     // set `compressionPreferred = true`). Local Serial / WebSocket leave
     // it false: bytes are cheap there and decompression adds latency.
     this.compressionEnabled = !!(transport && transport.compressionPreferred);
+    // GetState PriorHash short-circuit cache. Keyed by the combination of
+    // scope (sorted nsIds) and whether drafts were requested, so panel
+    // fetches with/without drafts each maintain their own cache line. The
+    // cache is cleared wholesale by any op that could change server-side
+    // state (setState, commit, discard, factoryReset, requestReboot).
+    this._stateHashes = new Map();
+    this._stateCache  = new Map();
+  }
+  // Cache key for GetState calls — combines the requested scope (sorted
+  // nsIds) with the withDrafts flag so a fetch that includes drafts doesn't
+  // collide with a working-only fetch of the same scope.
+  _stateCacheKey(nsIds, withDrafts){
+    const scope = Array.isArray(nsIds) && nsIds.length
+      ? JSON.stringify([...nsIds].map(Number).sort((a, b) => a - b))
+      : '[]';
+    return (withDrafts ? 'd|' : 'w|') + scope;
+  }
+  // Called after any op that may have changed server-side state. Blows away
+  // the state cache so the next fetch is unconditional and populates it
+  // freshly. Conservative: mutations to drafts and working both invalidate
+  // all cache lines, since a change to either invalidates any cached body
+  // that included the other.
+  _invalidateStateCache(){
+    this._stateHashes.clear();
+    this._stateCache.clear();
   }
   _onFrame(cmd, payload){
     if (cmd === CMD_PROVISION_RSP) this._onResponse(payload);
@@ -1592,8 +1642,20 @@ class ProvisioningClient {
       schemaHash: m.get(IK.SchemaHash),
     };
   }
-  async getSchema(){
-    const { body } = await this._request(OP.GetSchema);
+  // Fetch schema. `nsIds` is optional; when provided, only those namespaces
+  // are returned (server-side NamespaceFilter). The response array shape is
+  // unchanged — same [[id, name, parent, fields], ...] entries — so callers
+  // can concat multiple filtered fetches to assemble a complete schema.
+  async getSchema(nsIds){
+    const { body } = await this._request(OP.GetSchema, (p, ctx) => {
+      const hasFilter = Array.isArray(nsIds) && nsIds.length > 0;
+      const compress = !!(ctx && ctx.wantsCompress);
+      const entries = (hasFilter ? 1 : 0) + (compress ? 1 : 0);
+      if (entries === 0) { p.nil(); return; }
+      p.map(entries);
+      if (hasFilter) { p.int(GK.NamespaceFilter); p.arr(nsIds.length); for (const n of nsIds) p.int(Number(n)); }
+      if (compress) { p.int(WK.ReqCompress); p.bool(true); }
+    });
     const namespaces = [];
     if (Array.isArray(body)) {
       for (const nsEntry of body) {
@@ -1631,66 +1693,171 @@ class ProvisioningClient {
     }
     return { namespaces };
   }
-  // Resolve the device's schema, preferring (1) a build-time bundled schema
-  // whose hash matches the device, then (2) a localStorage cache entry keyed
-  // by (schemaVersion, schemaHash), then (3) a network GetSchema fetch. The
-  // hash is the CRC32 the firmware computes over the GetSchema response
-  // bytes at boot and reports in GetInfo; identical hashes imply identical
-  // schemas, so no per-device key is needed.
-  //
-  // Firmware that predates SchemaHash returns info.schemaHash === undefined,
-  // in which case we bypass cache and bundle and just fetch as before.
-  async resolveSchema(info){
-    const hash = info && info.schemaHash;
-    const ver  = info && info.schemaVersion;
-    if (hash == null || ver == null) return await this.getSchema();
-    const hashHex = (Number(hash) >>> 0).toString(16).padStart(8, '0');
-    const cacheKey = `mrf_schema_v${Number(ver)}_${hashHex}`;
-    // 1) Bundled (zero network).
-    if (BUNDLED_SCHEMA &&
-        Number(BUNDLED_SCHEMA.version) === Number(ver) &&
-        (Number(BUNDLED_SCHEMA.hash) >>> 0) === (Number(hash) >>> 0) &&
-        typeof BUNDLED_SCHEMA.schemaJson === 'string') {
-      try { return _schemaDeserialize(BUNDLED_SCHEMA.schemaJson); } catch(_) {}
-    }
-    // 2) localStorage cache.
-    try {
-      const raw = window.localStorage && localStorage.getItem(cacheKey);
-      if (raw) return _schemaDeserialize(raw);
-    } catch(_) {}
-    // 3) Fetch + persist.
-    const schema = await this.getSchema();
-    try {
-      if (window.localStorage) {
-        _schemaCachePrune(cacheKey);
-        localStorage.setItem(cacheKey, _schemaSerialize(schema));
-      }
-    } catch(_) { /* quota/disabled — non-fatal */ }
-    return schema;
-  }
-  async getState(nsIds, pending){
-    const { body } = await this._request(OP.GetState, (p, ctx) => {
-      const hasFilter = Array.isArray(nsIds) && nsIds.length > 0;
-      const compress = !!(ctx && ctx.wantsCompress);
-      const entries = (hasFilter ? 1 : 0) + (pending ? 1 : 0) + (compress ? 1 : 0);
-      if (entries === 0) { p.nil(); return; }
-      p.map(entries);
-      if (hasFilter) { p.int(GK.NamespaceFilter); p.arr(nsIds.length); for (const n of nsIds) p.int(n); }
-      if (pending) { p.int(GK.Pending); p.bool(true); }
-      if (compress) { p.int(WK.ReqCompress); p.bool(true); }
-    });
-    const out = {};
-    if (body instanceof Map) {
-      for (const [nsId, fields] of body) {
-        const f = {};
-        if (fields instanceof Map) for (const [fid, v] of fields) f[Number(fid)] = v;
-        out[Number(nsId)] = f;
+  // Fetch the namespace hierarchy map. One-shot at connect time; the returned
+  // per-namespace schemaHash values gate resolveSchema's per-namespace cache
+  // lookups. Response is an array of {id, name, parentId, fieldCount, schemaHash}.
+  async getCapabilities(){
+    const { body } = await this._request(OP.GetCapabilities);
+    const out = [];
+    if (Array.isArray(body)) {
+      for (const entry of body) {
+        if (!(entry instanceof Map)) continue;
+        out.push({
+          id:         Number(entry.get(NSK.NsId)),
+          name:       String(entry.get(NSK.NsName) || ''),
+          parentId:   Number(entry.get(NSK.NsParent) || 0),
+          fieldCount: Number(entry.get(NSK.NsFieldCount) || 0),
+          schemaHash: Number(entry.get(NSK.NsSchemaHash) || 0),
+        });
       }
     }
     return out;
   }
-  async setState(stateMap){
-    const { body } = await this._request(OP.SetState, (p) => {
+  // Resolve the device's schema per-namespace: (1) fetch GetCapabilities to
+  // learn the namespace map and each namespace's schema hash, (2) pull each
+  // namespace's schema from a build-time bundle or localStorage when the
+  // hash matches, (3) issue a single filtered GetSchema for whichever
+  // namespaces are missing, and (4) assemble the schema object in
+  // capabilities order. The cache scheme is content-addressed by
+  // (nsId, schemaHash) so a firmware upgrade that only changes some
+  // namespaces re-fetches just those.
+  //
+  // `info` is unused today but kept in the signature for call-site symmetry
+  // with the previous implementation; older firmware without GetCapabilities
+  // would trip in getCapabilities() itself, which is fine — this device is
+  // too old to support the new protocol either way.
+  async resolveSchema(info){
+    void info;
+    const caps = await this.getCapabilities();
+    const nsBundleByHash = _bundledNsByHash();	// key = `${id}_${hashHex}`
+    const resolved = new Map();	// nsId → namespace entry
+    const missing = [];
+    for (const cap of caps) {
+      const key = _nsSchemaCacheKey(cap.id, cap.schemaHash);
+      // (1) Bundled — zero network.
+      const bundleKey = `${cap.id}_${(Number(cap.schemaHash) >>> 0).toString(16).padStart(8, '0')}`;
+      if (nsBundleByHash && nsBundleByHash.has(bundleKey)) {
+        try {
+          const ns = _schemaDeserialize(nsBundleByHash.get(bundleKey));
+          if (ns && typeof ns === 'object') { resolved.set(cap.id, ns); continue; }
+        } catch(_) {}
+      }
+      // (2) localStorage.
+      try {
+        const raw = window.localStorage && localStorage.getItem(key);
+        if (raw) {
+          const ns = _schemaDeserialize(raw);
+          if (ns && typeof ns === 'object') { resolved.set(cap.id, ns); continue; }
+        }
+      } catch(_) {}
+      // (3) Queue for a batched network fetch.
+      missing.push(cap.id);
+    }
+    if (missing.length > 0) {
+      const partial = await this.getSchema(missing);
+      const fetchedById = new Map();
+      for (const ns of (partial && partial.namespaces) || []) {
+        fetchedById.set(Number(ns.id), ns);
+      }
+      for (const nsId of missing) {
+        const ns = fetchedById.get(nsId);
+        if (!ns) continue;	// server may have dropped an unknown id
+        resolved.set(nsId, ns);
+        // Persist under (nsId, schemaHash). Look up the hash from caps —
+        // fetched schema entries don't carry the hash themselves.
+        const cap = caps.find(c => c.id === nsId);
+        if (cap && window.localStorage) {
+          try { localStorage.setItem(_nsSchemaCacheKey(nsId, cap.schemaHash), _schemaSerialize(ns)); }
+          catch(_) { /* quota/disabled — non-fatal */ }
+        }
+      }
+    }
+    // (4) Assemble in capabilities order so parent → child ordering is
+    // preserved for downstream renderers.
+    const namespaces = [];
+    for (const cap of caps) {
+      const ns = resolved.get(cap.id);
+      if (ns) namespaces.push(ns);
+    }
+    return { namespaces };
+  }
+  // Single GetState entry point. `options.withDrafts=true` asks the server
+  // to include drafts alongside working in the same response body — one
+  // round-trip covers both working and draft state.
+  //
+  // Return shape:
+  //   - Cache hit (server said Unchanged): { unchanged: true, values, drafts?, hash }
+  //     where values/drafts come from the client-side cache.
+  //   - Cache miss: { unchanged: false, values, drafts?, hash } with fresh
+  //     values/drafts and a new hash. The client caches these so a follow-up
+  //     call with the same scope can short-circuit.
+  //
+  // drafts is undefined for withDrafts=false and also for withDrafts=true
+  // responses where no in-scope namespace had drafts (server omits the key).
+  async getState(nsIds, options){
+    const withDrafts = !!(options && options.withDrafts);
+    const cacheKey = this._stateCacheKey(nsIds, withDrafts);
+    const priorHash = this._stateHashes.get(cacheKey);
+    const { body } = await this._request(OP.GetState, (p, ctx) => {
+      const hasFilter = Array.isArray(nsIds) && nsIds.length > 0;
+      const compress = !!(ctx && ctx.wantsCompress);
+      const hasPrior = priorHash != null;
+      const entries = (hasFilter ? 1 : 0) + (withDrafts ? 1 : 0) + (hasPrior ? 1 : 0) + (compress ? 1 : 0);
+      if (entries === 0) { p.nil(); return; }
+      p.map(entries);
+      if (hasFilter)  { p.int(GK.NamespaceFilter); p.arr(nsIds.length); for (const n of nsIds) p.int(Number(n)); }
+      if (withDrafts) { p.int(GK.Draft); p.bool(true); }
+      if (hasPrior)   { p.int(GK.PriorHash); p.int(Number(priorHash) >>> 0); }
+      if (compress)   { p.int(WK.ReqCompress); p.bool(true); }
+    });
+    const m = body instanceof Map ? body : new Map();
+    if (m.get(GSK.Unchanged) === true) {
+      const cached = this._stateCache.get(cacheKey) || { values: {} };
+      return {
+        unchanged: true,
+        values: cached.values,
+        drafts: cached.drafts,	// undefined if the cached body didn't have drafts
+        hash: priorHash,
+      };
+    }
+    const values = {};
+    const valuesMap = m.get(GSK.Values);
+    if (valuesMap instanceof Map) {
+      for (const [nsId, fields] of valuesMap) {
+        const f = {};
+        if (fields instanceof Map) for (const [fid, v] of fields) f[Number(fid)] = v;
+        values[Number(nsId)] = f;
+      }
+    }
+    let drafts;
+    const draftsMap = m.get(GSK.Drafts);
+    if (draftsMap instanceof Map) {
+      drafts = {};
+      for (const [nsId, fields] of draftsMap) {
+        const f = {};
+        if (fields instanceof Map) for (const [fid, v] of fields) f[Number(fid)] = v;
+        drafts[Number(nsId)] = f;
+      }
+    }
+    const hashRaw = m.get(GSK.Hash);
+    const hash = hashRaw != null ? (Number(hashRaw) >>> 0) : null;
+    if (hash != null) this._stateHashes.set(cacheKey, hash);
+    this._stateCache.set(cacheKey, { values, drafts });
+    return { unchanged: false, values, drafts, hash };
+  }
+  // Stage drafts on the server. Options:
+  //   includeState: when true, response includes post-write Values + Drafts
+  //                 + Hash for the touched namespaces, letting the caller
+  //                 refresh the panel without a follow-up GetState round-trip.
+  //
+  // Wire envelope: { State: {ns: {fid: value}}, IncludeState?: bool, ReqCompress?: bool }.
+  async setState(stateMap, options){
+    const includeState = !!(options && options.includeState);
+    const { body } = await this._request(OP.SetState, (p, ctx) => {
+      const compress = !!(ctx && ctx.wantsCompress);
+      const entries = 1 + (includeState ? 1 : 0) + (compress ? 1 : 0);
+      p.map(entries);
+      p.int(GK.State);
       const nsIds = Object.keys(stateMap).map(Number);
       p.map(nsIds.length);
       for (const nsId of nsIds) {
@@ -1700,21 +1867,107 @@ class ProvisioningClient {
         p.map(fids.length);
         for (const fid of fids) { p.int(fid); packTypedValue(p, fields[fid].type, fields[fid].value); }
       }
+      if (includeState) { p.int(CmK.IncludeState); p.bool(true); }
+      if (compress)     { p.int(WK.ReqCompress); p.bool(true); }
     });
     const m = body instanceof Map ? body : new Map();
     const errs = m.get(SK.FieldErrors);
     const fieldErrors = Array.isArray(errs) ? errs.map(e => ({
       ns: Number(e[0]), field: Number(e[1]), code: Number(e[2]), codeName: ERR_NAMES[Number(e[2])] || 'Unknown',
     })) : [];
-    return { applied: Number(m.get(SK.Applied) || 0), draftHasReboot: !!m.get(SK.DraftHasReboot), fieldErrors };
+    // Server-side draft state changed — invalidate the cache so the next
+    // fetch sees fresh drafts. If includeState delivered fresh Values+Drafts
+    // we'll re-prime the withDrafts=true cache line below.
+    this._invalidateStateCache();
+    // Optional post-write Values / Drafts / Hash. When present we can prime
+    // the client-side cache and hand the caller ready-to-apply maps.
+    let values, drafts, hash;
+    const valuesMap = m.get(POK.Values);
+    if (valuesMap instanceof Map) {
+      values = {};
+      for (const [nsId, fields] of valuesMap) {
+        const f = {};
+        if (fields instanceof Map) for (const [fid, v] of fields) f[Number(fid)] = v;
+        values[Number(nsId)] = f;
+      }
+    }
+    const draftsMap = m.get(POK.Drafts);
+    if (draftsMap instanceof Map) {
+      drafts = {};
+      for (const [nsId, fields] of draftsMap) {
+        const f = {};
+        if (fields instanceof Map) for (const [fid, v] of fields) f[Number(fid)] = v;
+        drafts[Number(nsId)] = f;
+      }
+    }
+    const hashRaw = m.get(POK.Hash);
+    if (hashRaw != null) hash = (Number(hashRaw) >>> 0);
+    if (values && hash != null) {
+      // Prime the withDrafts=true cache line for the touched scope so a
+      // follow-up getState with the same scope hits the PriorHash short-
+      // circuit. Server-side Hash covers Values + Drafts (matching what
+      // op_get_state would emit for the same scope + withDrafts:true).
+      const touchedIds = Object.keys(values).map(Number);
+      if (touchedIds.length > 0) {
+        const cacheKey = this._stateCacheKey(touchedIds, true);
+        this._stateHashes.set(cacheKey, hash);
+        this._stateCache.set(cacheKey, { values, drafts });
+      }
+    }
+    return {
+      applied: Number(m.get(SK.Applied) || 0),
+      draftHasReboot: !!m.get(SK.DraftHasReboot),
+      fieldErrors,
+      values,
+      drafts,
+      hash,
+    };
   }
-  async commit(nsIds){
-    const { body } = await this._request(OP.Commit, (p) => {
-      if (Array.isArray(nsIds) && nsIds.length > 0) { p.arr(nsIds.length); for (const n of nsIds) p.int(n); }
-      else p.nil();
+  // Commit pending drafts. Options:
+  //   nsIds:        optional array — restricts commit to these namespaces
+  //   includeState: when true, response includes post-commit Values + Hash
+  //                 for the affected namespaces, letting the caller refresh
+  //                 the UI without a follow-up GetState round-trip.
+  async commit(nsIds, options){
+    const includeState = !!(options && options.includeState);
+    const { body } = await this._request(OP.Commit, (p, ctx) => {
+      const hasFilter = Array.isArray(nsIds) && nsIds.length > 0;
+      const compress = !!(ctx && ctx.wantsCompress);
+      const entries = (hasFilter ? 1 : 0) + (includeState ? 1 : 0) + (compress ? 1 : 0);
+      if (entries === 0) { p.nil(); return; }
+      p.map(entries);
+      if (hasFilter)    { p.int(GK.NamespaceFilter); p.arr(nsIds.length); for (const n of nsIds) p.int(Number(n)); }
+      if (includeState) { p.int(CmK.IncludeState); p.bool(true); }
+      if (compress)     { p.int(WK.ReqCompress); p.bool(true); }
     });
     const m = body instanceof Map ? body : new Map();
-    return { applied: Number(m.get(CK.Applied) || 0), needsReboot: !!m.get(CK.NeedsReboot) };
+    this._invalidateStateCache();
+    const applied = Number(m.get(CK.Applied) || 0);
+    const needsReboot = !!m.get(CK.NeedsReboot);
+    // Optional post-commit Values / Hash. When present we can prime the
+    // client-side cache so a follow-up getState with the same withDrafts=false
+    // scope hits the PriorHash short-circuit.
+    let values, hash;
+    const valuesMap = m.get(POK.Values);
+    if (valuesMap instanceof Map) {
+      values = {};
+      for (const [nsId, fields] of valuesMap) {
+        const f = {};
+        if (fields instanceof Map) for (const [fid, v] of fields) f[Number(fid)] = v;
+        values[Number(nsId)] = f;
+      }
+    }
+    const hashRaw = m.get(POK.Hash);
+    if (hashRaw != null) hash = (Number(hashRaw) >>> 0);
+    if (values && hash != null && Array.isArray(nsIds) && nsIds.length > 0) {
+      // Prime the withDrafts=false cache line for this exact scope — the
+      // response body's Values is what a fresh working-only GetState would
+      // return for the same nsIds.
+      const cacheKey = this._stateCacheKey(nsIds, false);
+      this._stateHashes.set(cacheKey, hash);
+      this._stateCache.set(cacheKey, { values });
+    }
+    return { applied, needsReboot, values, hash };
   }
   async discard(nsIds){
     const { body } = await this._request(OP.Discard, (p) => {
@@ -1722,11 +1975,13 @@ class ProvisioningClient {
       else p.nil();
     });
     const m = body instanceof Map ? body : new Map();
+    this._invalidateStateCache();
     return { applied: Number(m.get(CK.Applied) || 0) };
   }
   async factoryReset(){
     const { body } = await this._request(OP.FactoryReset);
     const m = body instanceof Map ? body : new Map();
+    this._invalidateStateCache();
     return { needsReboot: !!m.get(CK.NeedsReboot) };
   }
   // First-class Provisioning reboot — the library sends an Ack before
@@ -1738,6 +1993,9 @@ class ProvisioningClient {
   // too old to know about OP.Reboot — so callers can fall back cleanly to
   // the legacy KISS reset path.
   async requestReboot(){
+    // Invalidate proactively — a successful reboot resets device-side state
+    // and any pre-reboot hashes we're carrying would be stale on reconnect.
+    this._invalidateStateCache();
     try {
       await this._request(OP.Reboot, null, 3000);
     } catch (e) {
@@ -1751,6 +2009,7 @@ class ProvisioningClient {
   // so there is no response — we just send the bytes. Used as the fallback
   // for legacy RNodes that don't implement OP.Reboot.
   async reboot(){
+    this._invalidateStateCache();
     await this.t.send(kissEncode(CMD_RESET, new Uint8Array([CMD_RESET_BYTE])));
   }
   // Called after the underlying transport reconnects (post-reboot). Clears
@@ -1766,6 +2025,10 @@ class ProvisioningClient {
     this.decoder = new KissDecoder((cmd, payload) => this._onFrame(cmd, payload));
     this.t.onBytes = (b) => this.decoder.feed(b);
     this.seq = 1;
+    // Any state cached from the pre-disconnect session may not reflect what
+    // the device now holds (could have rebooted, could have had drafts
+    // dropped, could be a different device via KISS-over-BLE). Start clean.
+    this._invalidateStateCache();
   }
 }
 function packTypedValue(p, type, v){
@@ -2368,10 +2631,14 @@ async function startReconnect(){
   state.conn.set({ state: 'idle' });
 }
 async function fetchNamespaceIfNeeded(nsId){
-  // The argument is a ROOT namespace id. Fetches that namespace AND all of its
-  // descendants in two batched getState calls (one for committed, one for
-  // merged-with-draft). Each child is populated into state.nsState alongside
-  // the root so the panel can render them as sub-sections.
+  // The argument is a ROOT namespace id. Fetches that namespace AND all of
+  // its descendants: one getWorkingState call to populate committed values
+  // and learn which sub-namespaces hold drafts, then (conditionally) a
+  // targeted getDraftState for just those. Both calls are hash-cached in
+  // the client, so refetches after nothing has changed return a tiny
+  // { Unchanged: true } body — the client transparently substitutes cached
+  // values. Each child is populated into state.nsState alongside the root
+  // so the panel can render them as sub-sections.
   if (!client) return;
   const schema = state.schema.get();
   const ids = getNsTreeIds(schema, nsId);
@@ -2383,37 +2650,28 @@ async function fetchNamespaceIfNeeded(nsId){
   if (todo.length === 0) return;
   state.nsLoading.update(s => { for (const id of todo) s[id] = true; });
   try {
-    const committedAll = await client.getState(todo, false);
-    const mergedAll    = await client.getState(todo, true);
+    // Single call: server returns Values (working) and Drafts (sparse map
+    // of drafted fields) in the same response body, delivered in one
+    // round-trip. Eliminates the previous double-fetch pattern and its
+    // "live metric drift produces phantom drafts" workaround.
+    const resp = await client.getState(todo, { withDrafts: true });
+    const committedAll = resp.values || {};
+    const draftsAll = resp.drafts || {};	// undefined → no drafts anywhere
+
     let firmwareDraftAny = false;
     state.nsState.update(s => {
       for (const id of todo) {
         const committed = committedAll[id] || {};
-        const merged    = mergedAll[id]    || {};
-        // FF_READ_ONLY fields (metrics/instrumentation) report live runtime
-        // values via their getter. Two consecutive GetState calls — one for
-        // committed, one for merged — can sample slightly different values
-        // (e.g. current_rssi, channel utilisation), producing a phantom
-        // "draft" diff that's really just live-value drift. Build a set of
-        // read-only fids up front and exclude them from the diff so the
-        // pending-changes count never reflects this drift.
-        const ns = getNsById(schema, id);
-        const roFids = new Set();
-        if (ns && Array.isArray(ns.fields)) {
-          for (const f of ns.fields) if ((f.flags|0) & FF.READ_ONLY) roFids.add(Number(f.id));
-        }
+        const draftFields = draftsAll[id] || {};
         const draft = {};
         const firmwareDraftFids = new Set();
-        for (const fid in merged) {
-          const nfid = Number(fid);
-          if (roFids.has(nfid)) continue;
-          if (!valuesEqual(merged[fid], committed[fid])) {
-            draft[nfid] = merged[fid];
-            firmwareDraftFids.add(nfid);
-          }
+        for (const fidStr in draftFields) {
+          const nfid = Number(fidStr);
+          draft[nfid] = draftFields[fidStr];
+          firmwareDraftFids.add(nfid);
         }
-        s[id] = { committed, draft, firmwareDraftFids };
         if (firmwareDraftFids.size > 0) firmwareDraftAny = true;
+        s[id] = { committed, draft, firmwareDraftFids };
       }
     });
     state.nsLoaded.update(s => { for (const id of todo) s[id] = true; });
@@ -2546,6 +2804,8 @@ function getNsTreeIds(schema, rootId){
   walk(rootId);
   return out;
 }
+// True iff the namespace has at least one field that could carry a draft —
+// i.e. at least one field whose flags carry neither FF_READ_ONLY (metrics /
 // Total drafted-field count across a namespace and all its descendants. Used
 // for the sidenav "•" indicator on root namespaces.
 function nsTreeDraftCount(schema, rootId, ctx){
@@ -2592,7 +2852,10 @@ async function saveNamespace(nsId){
   }
   if (Object.keys(stateMap).length === 0) return;
   try {
-    const r = await client.setState(stateMap);
+    // includeState:true — the setState response includes the touched
+    // namespaces' post-write Values and Drafts, so we can refresh
+    // state.nsState directly without a follow-up GetState round-trip.
+    const r = await client.setState(stateMap, { includeState: true });
     // Spread server-side field errors back to their owning namespace.
     const perNs = {};
     for (const fe of r.fieldErrors) {
@@ -2600,9 +2863,34 @@ async function saveNamespace(nsId){
       perNs[fe.ns][fe.field] = fe.codeName;
     }
     state.nsServerErrors.update(s => { for (const id of treeIds) s[id] = perNs[id] || {}; });
-    state.nsLoaded.update(s => { for (const id of treeIds) delete s[id]; });
     if (r.applied > 0) state.firmwareHasDraft.set(true);
-    await fetchNamespaceIfNeeded(nsId);
+    if (r.values) {
+      // Apply returned Values + Drafts directly to state.nsState. The
+      // committed values are what working() would report; drafts are the
+      // firmware-side draft entries after set_draft's dedup logic ran.
+      state.nsState.update(s => {
+        for (const idStr in r.values) {
+          const nid = Number(idStr);
+          const committed = r.values[idStr];
+          const draftFields = (r.drafts && r.drafts[idStr]) || {};
+          const draft = {};
+          const firmwareDraftFids = new Set();
+          for (const fidStr in draftFields) {
+            const nfid = Number(fidStr);
+            draft[nfid] = draftFields[fidStr];
+            firmwareDraftFids.add(nfid);
+          }
+          s[nid] = { committed, draft, firmwareDraftFids };
+        }
+      });
+      state.nsLoaded.update(s => { for (const id of treeIds) s[id] = true; });
+      recomputeHasDraft();
+    } else {
+      // Older firmware without IncludeState support — fall back to the
+      // pre-Phase-3.6 refetch path.
+      state.nsLoaded.update(s => { for (const id of treeIds) delete s[id]; });
+      await fetchNamespaceIfNeeded(nsId);
+    }
     const ns = getNsById(schema, nsId);
     const label = ns ? ns.name : String(nsId);
     if (r.fieldErrors.length === 0) {
@@ -2640,16 +2928,49 @@ async function commitAll(){
   if (!client) return;
   if (!confirm('Commit all pending changes to the device?')) return;
   try {
-    const r = await client.commit(null);
+    // includeState=true: the commit response includes the post-commit
+    // working values for touched namespaces, letting us update state.nsState
+    // directly without a follow-up GetState round-trip.
+    const r = await client.commit(null, { includeState: true });
     state.nsServerErrors.set({});
-    state.nsLoaded.set({});
-    state.nsState.set({});
+    if (r.values) {
+      // Populate state.nsState from the returned Values. Namespaces that
+      // weren't touched by the commit (no drafts) are not in r.values —
+      // clear them so the panel refresh path re-fetches when reopened.
+      const touched = new Set(Object.keys(r.values).map(Number));
+      state.nsState.update(s => {
+        for (const nsIdStr in r.values) {
+          const nsIdN = Number(nsIdStr);
+          s[nsIdN] = { committed: r.values[nsIdStr], draft: {}, firmwareDraftFids: new Set() };
+        }
+        for (const idStr in s) {
+          if (!touched.has(Number(idStr))) delete s[idStr];
+        }
+      });
+      state.nsLoaded.update(s => {
+        for (const nsIdStr in r.values) s[Number(nsIdStr)] = true;
+        for (const idStr in s) {
+          if (!touched.has(Number(idStr))) delete s[idStr];
+        }
+      });
+    } else {
+      // Older firmware without IncludeState support — fall back to the
+      // pre-Phase-3 behavior: clear and refetch on next panel open.
+      state.nsLoaded.set({});
+      state.nsState.set({});
+    }
     recomputeHasDraft();
     state.firmwareHasDraft.set(false);
-    // Banner is derived from state.info.needsReboot; re-fetching info updates it.
-    try { state.info.set(await client.getInfo()); } catch(_) {}
-    const cur = state.activeNsTab.get();
-    if (cur != null) await fetchNamespaceIfNeeded(cur);
+    // "Reboot recommended" banner reads state.info.needsReboot. The commit
+    // response already carries the fresh value — patch state.info in place
+    // rather than making a second round-trip for GetInfo.
+    state.info.update(info => info ? { ...info, needsReboot: r.needsReboot } : info);
+    // With Values applied above the active panel already reflects the
+    // committed state; only refetch when we didn't get Values back.
+    if (!r.values) {
+      const cur = state.activeNsTab.get();
+      if (cur != null) await fetchNamespaceIfNeeded(cur);
+    }
     showToast(`Committed ${r.applied} change${r.applied !== 1 ? 's' : ''}` + (r.needsReboot ? ' — reboot recommended' : ''), r.needsReboot ? 'warn' : 'ok');
   } catch (e) {
     showToast('Commit failed: ' + e.message, 'err');


### PR DESCRIPTION
Web console: adopt merged/cached provisioning wire format.
Follow-on to the microReticulum protocol rework. Save and Commit each
collapse from two transactions to one; reopening a namespace panel with
unchanged state short-circuits via PriorHash to a tiny
{ Unchanged: true } response body.

- Replace client.getWorkingState + client.getDraftState with a single
  client.getState(nsIds, { withDrafts }) that parses the merged
  { Values, Drafts?, Hash } response.
- Per-scope PriorHash cache in the client (keyed by sorted nsIds +
  withDrafts flag); invalidate on any mutation op.
- client.setState(stateMap, { includeState }) wraps writes in the new
  { State, IncludeState } envelope and parses PostOp values/drafts/hash;
  saveNamespace applies them directly to state.nsState with no follow-up
  fetchNamespaceIfNeeded.
- client.commit(nsIds, { includeState }) uses the new map request format;
  commitAll applies returned working values directly and updates
  state.info.needsReboot from r.needsReboot — no separate getInfo call,
  no follow-up refresh.
- Per-namespace schema cache (mrf_schema_ns${id}_${hash}) replaces the
  single-blob mrf_schema_v${ver}_${hash} cache; resolveSchema uses
  GetCapabilities to learn per-namespace hashes and only fetches missing
  entries via GetSchema with a NamespaceFilter.
- Delete the "phantom draft from live-metric drift" workaround (roFids
  filtering) that the double-fetch design required — the server is now
  authoritative about which fields have drafts, so no client-side diff.

Web console: add Settings tab; persist defaults to localStorage
- New "Settings" tab (first, always available) with sections for General,
  Serial, Bluetooth, WebSocket, and RNS. Defaults persist to localStorage
  under 'rnode.console.settings.v1' and pre-fill top-bar fields at launch.
- Serial / Bluetooth default-device dropdowns populated from
  navigator.serial.getPorts() and navigator.bluetooth.getDevices() (BLE
  gracefully degrades when getDevices is unavailable). doConnect skips the
  browser picker when the stored default is still authorized.
- Per-transport auto-reconnect defaults; the banner's shared auto-reconnect
  checkbox re-seeds from the selected transport's default on switch.
- Move rnsapid URL and 'identify' checkbox from the top-bar to the Settings
  RNS section (destination hash remains in the top-bar for per-session use).
- On successful connect, immediately switch to Node Status (before the
  getInfo/schema/legacy-probe fetches complete) so the tab change confirms
  the connection while the body shows its existing waiting placeholder.
- Cosmetic: move auto-reconnect to the left of Connect/Disconnect; rename
  the "RNS (via rnsapid)" transport option to just "RNS".
- Rebuild Release/console.html via webconsole/package.sh.
- Documentation updates to docs/Provisioning.md.