### PR TITLE
Add Heltec Wireless Tracker V2 support courtesy of @evelant

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -881,6 +881,11 @@
       #define HAS_LORA_LNA   true
       #define LORA_LNA_GAIN  12
       #define LORA_LNA_GVT   8
+      // LNA_GD_x matching HELTEC32_V4 since both boards run the SX1262,
+      // the gain-drift artifact these macros compensate for is a property
+      // of the SX1262 RX chain's LNA/AGC, not of the external FEM.
+      #define LNA_GD_THRSHLD (-109)
+      #define LNA_GD_LIMIT   (-89)
 
       // SKY66122 FEM is controlled via pin_rxen (WB_IO3) and SX1262 DIO2 (DIO2_AS_RF_SWITCH).
       // Use LORA_PA_UNKNOWN so sx126x model-specific branches are skipped.

--- a/Boards.h
+++ b/Boards.h
@@ -101,6 +101,10 @@
   #define BOARD_HELTEC32_V4   0x3F
   #define MODEL_C8            0xC8 // Heltec Lora32 v3, 850-950 MHz, 28dBm
 
+  #define PRODUCT_HTRACKER_V2 0xC4
+  #define BOARD_HELTEC_TRACKER_V2 0x45
+  #define MODEL_CB            0xCB // Heltec Wireless Tracker V2, 863-928 MHz, 28dBm
+
   #define PRODUCT_HELTEC_T114 0xC2 // Heltec Mesh Node T114
   #define BOARD_HELTEC_T114   0x3C
   #define MODEL_C6            0xC6 // Heltec Mesh Node T114, 470-510 MHz
@@ -462,6 +466,67 @@
       const int PA_GC1109_VALUES[PA_GAIN_POINTS] =   {11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10,  9, 9, 8, 7};
       const int PA_KCT8103L_VALUES[PA_GAIN_POINTS] = {13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 12, 12, 11, 11, 10, 9, 8, 7};
 
+      const int pin_cs = 8;
+      const int pin_busy = 13;
+      const int pin_dio = 14;
+      const int pin_reset = 12;
+      const int pin_mosi = 10;
+      const int pin_miso = 11;
+      const int pin_sclk = 9;
+
+    #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+      #define IS_ESP32S3 true
+      #define HAS_DISPLAY true
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_WIFI true
+      #define HAS_PMU true
+      #define HAS_EEPROM true
+      #define HAS_INPUT true
+      #define HAS_SLEEP true
+      #define HAS_LORA_PA true
+      #define HAS_LORA_LNA true
+      #define PIN_WAKEUP GPIO_NUM_0
+      #define WAKEUP_LEVEL 0
+      #define OCP_TUNED 0x28
+
+      // Vext powers the onboard TFT and GNSS. The Tracker V2.3 schematic
+      // drives its high-side switch through an NPN, making GPIO3 active HIGH.
+      #define Vext GPIO_NUM_3
+      #define VEXT_ON HIGH
+      #define VEXT_OFF LOW
+
+      const int pin_btn_usr1 = 0;
+
+      // Leave the separate GPIO18 status LED unused for RX/TX activity.
+      // The TFT backlight is controlled independently on GPIO21.
+      const int pin_led_rx = -1;
+      const int pin_led_tx = -1;
+
+      #define MODEM SX1262
+      #define HAS_TCXO true
+      const int pin_tcxo_enable = -1;
+      #define HAS_BUSY true
+      #define DIO2_AS_RF_SWITCH true
+
+      // KCT8103L RF front end. SX1262 DIO2 drives PA_CPS directly.
+      #define LORA_PA_MODEL LORA_PA_KCT8103L
+      #define LORA_PA_PWR_EN 7
+      #define LORA_PA_CSD 4
+      #define LORA_PA_CTX 5
+      #define LORA_PA_CPS 46
+      #define LORA_LNA_GAIN 21
+      #define LORA_LNA_GVT 12
+      #define LNA_GD_THRSHLD (-109)
+      #define LNA_GD_LIMIT (-89)
+
+      #define PA_MAX_OUTPUT 28
+      #define PA_GAIN_POINTS 22
+      // Antenna-path gain from Heltec's Tracker V2.3 power table, indexed by
+      // SX1262 output from 0 through 21 dBm.
+      #define PA_GAIN_VALUES 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 13, 13, 13, 12, 12, 11, 10, 9, 8, 7
+
+      // Onboard SX1262 SPI and control pins.
       const int pin_cs = 8;
       const int pin_busy = 13;
       const int pin_dio = 14;

--- a/Display.h
+++ b/Display.h
@@ -17,14 +17,14 @@
 #include <Adafruit_GFX.h>
 
 #if BOARD_MODEL != BOARD_TECHO
-  #if BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
-    #include <SPI.h>
-    #include <Adafruit_ST7735.h>
-  #elif BOARD_MODEL == BOARD_TDECK
+  #if BOARD_MODEL == BOARD_TDECK
     #include <Adafruit_ST7789.h>
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     #include "ST7789.h"
     #define COLOR565(r, g, b) (((r & 0xF8) << 8) | ((g & 0xFC) << 3) | ((b & 0xF8) >> 3))
+  #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+    #include <SPI.h>
+    #include <Adafruit_ST7735.h>
   #elif BOARD_MODEL == BOARD_TBEAM_S_V1
     #include <Adafruit_SH110X.h>
   #else
@@ -82,7 +82,7 @@
   #define DISPLAY_MOSI 42
   #define DISPLAY_DC 40
   #define DISPLAY_BL_PIN 21
-#elif BOARD_MODEL == BOARD_RAK4631
+#elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
   // RAK1921/SSD1306
   #define DISP_RST -1
   #define DISP_ADDR 0x3C
@@ -121,19 +121,19 @@
 
 #define SMALL_FONT &Org_01
 
-#if BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
-  // Keep the TFT on the ESP32-S3's second SPI controller. The SX1262 uses
-  // the default controller on GPIO 8-11, while the TFT has its own pin set.
-  SPIClass displaySPI = SPIClass(HSPI);
-  Adafruit_ST7735 display(&displaySPI, DISPLAY_CS, DISPLAY_DC, DISP_RST);
-  #define SSD1306_WHITE ST77XX_WHITE
-  #define SSD1306_BLACK ST77XX_BLACK
-#elif BOARD_MODEL == BOARD_TDECK
+#if BOARD_MODEL == BOARD_TDECK
   Adafruit_ST7789 display = Adafruit_ST7789(DISPLAY_CS, DISPLAY_DC, -1);
   #define SSD1306_WHITE ST77XX_WHITE
   #define SSD1306_BLACK ST77XX_BLACK
 #elif BOARD_MODEL == BOARD_HELTEC_T114
   ST7789Spi display(&SPI1, DISPLAY_RST, DISPLAY_DC, DISPLAY_CS);
+  #define SSD1306_WHITE ST77XX_WHITE
+  #define SSD1306_BLACK ST77XX_BLACK
+#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+  // Keep the TFT on the ESP32-S3's second SPI controller. The SX1262 uses
+  // the default controller on GPIO 8-11, while the TFT has its own pin set.
+  SPIClass displaySPI = SPIClass(HSPI);
+  Adafruit_ST7735 display(&displaySPI, DISPLAY_CS, DISPLAY_DC, DISP_RST);
   #define SSD1306_WHITE ST77XX_WHITE
   #define SSD1306_BLACK ST77XX_BLACK
 #elif BOARD_MODEL == BOARD_TBEAM_S_V1
@@ -262,6 +262,12 @@ uint8_t display_contrast = 0x00;
   }
 #elif BOARD_MODEL == BOARD_HELTEC_T114
   void set_contrast(ST7789Spi *display, uint8_t value) { }
+#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+  // The Adafruit_ST7735 display lacks a brightness register.
+  // Control of the LED backlight requires PWM on the backlight pin.
+  void set_contrast(Adafruit_ST7735 *display, uint8_t value) {
+    digitalWrite(DISPLAY_BL_PIN, value == 0 ? LOW : HIGH);
+  }
 #elif BOARD_MODEL == BOARD_TECHO
   void set_contrast(void *display, uint8_t value) {
     if (value == 0) { analogWrite(pin_backlight, 0); }
@@ -291,10 +297,6 @@ uint8_t display_contrast = 0x00;
         digitalWrite(DISPLAY_BL_PIN, 1);
     }
     level = value;
-  }
-#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
-  void set_contrast(Adafruit_ST7735 *display, uint8_t value) {
-    digitalWrite(DISPLAY_BL_PIN, value == 0 ? LOW : HIGH);
   }
 #else
   void set_contrast(Adafruit_SSD1306 *display, uint8_t contrast) {
@@ -413,14 +415,14 @@ bool display_init() {
     #elif BOARD_MODEL == BOARD_TDECK
     display.init(240, 320);
     display.setSPISpeed(80e6);
-    #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
-    displaySPI.begin(DISPLAY_SCLK, -1, DISPLAY_MOSI, DISPLAY_CS);
-    display.initR(INITR_MINI160x80_PLUGIN);
-    if (false) {
     #elif BOARD_MODEL == BOARD_HELTEC_T114
     display.init();
     // set white as default pixel colour for Heltec T114
     display.setRGB(COLOR565(0xFF, 0xFF, 0xFF));
+    if (false) {
+    #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+    displaySPI.begin(DISPLAY_SCLK, -1, DISPLAY_MOSI, DISPLAY_CS);
+    display.initR(INITR_MINI160x80_PLUGIN);
     if (false) {
     #elif BOARD_MODEL == BOARD_TBEAM_S_V1
     if (!display.begin(display_address, true)) {
@@ -474,7 +476,7 @@ bool display_init() {
         #elif BOARD_MODEL == BOARD_HELTEC_T114
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_RAK4631
+        #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
           disp_mode = DISP_MODE_LANDSCAPE;
           display.setRotation(0);
         #elif BOARD_MODEL == BOARD_TDECK

--- a/Display.h
+++ b/Display.h
@@ -17,7 +17,10 @@
 #include <Adafruit_GFX.h>
 
 #if BOARD_MODEL != BOARD_TECHO
-  #if BOARD_MODEL == BOARD_TDECK
+  #if BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+    #include <SPI.h>
+    #include <Adafruit_ST7735.h>
+  #elif BOARD_MODEL == BOARD_TDECK
     #include <Adafruit_ST7789.h>
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     #include "ST7789.h"
@@ -40,8 +43,13 @@
 #endif
 
 #include "Fonts/Org_01.h"
-#define DISP_W 128
-#define DISP_H 64
+#if BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+  #define DISP_W 160
+  #define DISP_H 80
+#else
+  #define DISP_W 128
+  #define DISP_H 64
+#endif
 
 #if BOARD_MODEL == BOARD_RNODE_NG_20 || BOARD_MODEL == BOARD_LORA32_V2_0
   #define DISP_RST -1
@@ -65,6 +73,15 @@
   #define DISP_ADDR 0x3C
   #define SCL_OLED 18
   #define SDA_OLED 17
+#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+  #define DISP_RST 39
+  #define DISP_ADDR -1
+  #define DISP_CUSTOM_ADDR false
+  #define DISPLAY_CS 38
+  #define DISPLAY_SCLK 41
+  #define DISPLAY_MOSI 42
+  #define DISPLAY_DC 40
+  #define DISPLAY_BL_PIN 21
 #elif BOARD_MODEL == BOARD_RAK4631
   // RAK1921/SSD1306
   #define DISP_RST -1
@@ -104,7 +121,14 @@
 
 #define SMALL_FONT &Org_01
 
-#if BOARD_MODEL == BOARD_TDECK
+#if BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+  // Keep the TFT on the ESP32-S3's second SPI controller. The SX1262 uses
+  // the default controller on GPIO 8-11, while the TFT has its own pin set.
+  SPIClass displaySPI = SPIClass(HSPI);
+  Adafruit_ST7735 display(&displaySPI, DISPLAY_CS, DISPLAY_DC, DISP_RST);
+  #define SSD1306_WHITE ST77XX_WHITE
+  #define SSD1306_BLACK ST77XX_BLACK
+#elif BOARD_MODEL == BOARD_TDECK
   Adafruit_ST7789 display = Adafruit_ST7789(DISPLAY_CS, DISPLAY_DC, -1);
   #define SSD1306_WHITE ST77XX_WHITE
   #define SSD1306_BLACK ST77XX_BLACK
@@ -197,6 +221,14 @@ void update_area_positions() {
       p_as_x = 126;
       p_as_y = p_ad_y;
     }
+  #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+    // Centre the inherited 130x64 landscape UI on the 160x80 TFT. The
+    // status area is offset by two pixels below to leave room for its
+    // separator, so the base positions account for that total width.
+    p_ad_x = 15;
+    p_ad_y = 8;
+    p_as_x = 79;
+    p_as_y = 8;
   #elif BOARD_MODEL == BOARD_TECHO
     if (disp_mode == DISP_MODE_PORTRAIT) {
       p_ad_x = 61;
@@ -260,6 +292,10 @@ uint8_t display_contrast = 0x00;
     }
     level = value;
   }
+#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+  void set_contrast(Adafruit_ST7735 *display, uint8_t value) {
+    digitalWrite(DISPLAY_BL_PIN, value == 0 ? LOW : HIGH);
+  }
 #else
   void set_contrast(Adafruit_SSD1306 *display, uint8_t contrast) {
     display->ssd1306_command(SSD1306_SETCONTRAST);
@@ -302,6 +338,12 @@ bool display_init() {
       digitalWrite(pin_display_en, HIGH);
       delay(50);
       Wire.begin(SDA_OLED, SCL_OLED);
+    #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+      pinMode(Vext, OUTPUT);
+      digitalWrite(Vext, VEXT_ON);
+      pinMode(DISPLAY_BL_PIN, OUTPUT);
+      digitalWrite(DISPLAY_BL_PIN, HIGH);
+      delay(50);
     #elif BOARD_MODEL == BOARD_LORA32_V1_0
       int pin_display_en = 16;
       digitalWrite(pin_display_en, LOW);
@@ -371,6 +413,10 @@ bool display_init() {
     #elif BOARD_MODEL == BOARD_TDECK
     display.init(240, 320);
     display.setSPISpeed(80e6);
+    #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+    displaySPI.begin(DISPLAY_SCLK, -1, DISPLAY_MOSI, DISPLAY_CS);
+    display.initR(INITR_MINI160x80_PLUGIN);
+    if (false) {
     #elif BOARD_MODEL == BOARD_HELTEC_T114
     display.init();
     // set white as default pixel colour for Heltec T114
@@ -422,6 +468,9 @@ bool display_init() {
         #elif BOARD_MODEL == BOARD_HELTEC32_V4
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
+        #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+          disp_mode = DISP_MODE_LANDSCAPE;
+          display.setRotation(1);
         #elif BOARD_MODEL == BOARD_HELTEC_T114
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
@@ -467,7 +516,7 @@ bool display_init() {
         #endif
       #endif
 
-      #if BOARD_MODEL == BOARD_TDECK
+      #if BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
         display.fillScreen(SSD1306_BLACK);
       #endif
 
@@ -785,7 +834,7 @@ void update_stat_area() {
       drawBitmap(p_as_x, p_as_y, stat_area.getBuffer(), stat_area.width(), stat_area.height(), SSD1306_WHITE, SSD1306_BLACK);
     } else if (disp_mode == DISP_MODE_LANDSCAPE) {
       drawBitmap(p_as_x+2, p_as_y, stat_area.getBuffer(), stat_area.width(), stat_area.height(), SSD1306_WHITE, SSD1306_BLACK);
-      if (device_init_done && !disp_ext_fb) drawLine(p_as_x, 0, p_as_x, 64, SSD1306_WHITE);
+      if (device_init_done && !disp_ext_fb) drawLine(p_as_x, p_as_y, p_as_x, p_as_y+stat_area.height()-1, SSD1306_WHITE);
     }
 
   } else {
@@ -794,7 +843,7 @@ void update_stat_area() {
     } else if (console_active && device_init_done) {
       drawBitmap(p_as_x, p_as_y, bm_console, stat_area.width(), stat_area.height(), SSD1306_BLACK, SSD1306_WHITE);
       if (disp_mode == DISP_MODE_LANDSCAPE) {
-        drawLine(p_as_x, 0, p_as_x, 64, SSD1306_WHITE);
+        drawLine(p_as_x, p_as_y, p_as_x, p_as_y+stat_area.height()-1, SSD1306_WHITE);
       }
     }
   }
@@ -1001,7 +1050,7 @@ void update_disp_area() {
   drawBitmap(p_ad_x, p_ad_y, disp_area.getBuffer(), disp_area.width(), disp_area.height(), SSD1306_WHITE, SSD1306_BLACK);
   if (disp_mode == DISP_MODE_LANDSCAPE) {
     if (device_init_done && !firmware_update_mode && !disp_ext_fb) {
-      drawLine(0, 0, 0, 63, SSD1306_WHITE);
+      drawLine(p_ad_x, p_ad_y, p_ad_x, p_ad_y+disp_area.height()-1, SSD1306_WHITE);
     }
   }
 }
@@ -1077,6 +1126,8 @@ void update_display(bool blank = false) {
         display.clear();
         display.display();
         digitalWrite(PIN_T114_TFT_BLGT, HIGH);
+      #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+        display.fillScreen(SSD1306_BLACK);
       #elif BOARD_MODEL != BOARD_TDECK && BOARD_MODEL != BOARD_TECHO
         display.clearDisplay();
         display.display();
@@ -1098,7 +1149,7 @@ void update_display(bool blank = false) {
       #if BOARD_MODEL == BOARD_HELTEC_T114
         display.clear();
         digitalWrite(PIN_T114_TFT_BLGT, LOW);
-      #elif BOARD_MODEL != BOARD_TDECK && BOARD_MODEL != BOARD_TECHO
+      #elif BOARD_MODEL != BOARD_TDECK && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_HELTEC_TRACKER_V2
         display.clearDisplay();
       #endif
 
@@ -1123,7 +1174,7 @@ void update_display(bool blank = false) {
           last_epd_refresh = millis();
           epd_blanked = false;
         }
-      #elif BOARD_MODEL != BOARD_TDECK
+      #elif BOARD_MODEL != BOARD_TDECK && BOARD_MODEL != BOARD_HELTEC_TRACKER_V2
         display.display();
       #endif
 

--- a/Power.h
+++ b/Power.h
@@ -147,6 +147,23 @@ float pmu_temperature = PMU_TEMP_MIN-1;
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
+#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+  #define BAT_V_MIN       3.05
+  #define BAT_V_MAX       4.0
+  #define BAT_V_CHG       4.48
+  #define BAT_V_FLOAT     4.33
+  #define BAT_SAMPLES     7
+  const uint8_t pin_vbat = 1;
+  const uint8_t pin_ctrl = 2;
+  float bat_p_samples[BAT_SAMPLES];
+  float bat_v_samples[BAT_SAMPLES];
+  uint8_t bat_samples_count = 0;
+  int bat_discharging_samples = 0;
+  int bat_charging_samples = 0;
+  int bat_charged_samples = 0;
+  bool bat_voltage_dropping = false;
+  float bat_delay_v = 0;
+  float bat_state_change_v = 0;
 #elif BOARD_MODEL == BOARD_HELTEC_T114
   #define BAT_V_MIN       3.15
   #define BAT_V_MAX       4.165
@@ -218,9 +235,9 @@ void measure_temperature() {
 }
 
 void measure_battery() {
-  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
+  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_HELTEC_TRACKER_V2 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_RAK3401
     battery_installed = true;
-    #if BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4
+    #if BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
       battery_indeterminate = false;
     #else
       battery_indeterminate = true;
@@ -230,6 +247,9 @@ void measure_battery() {
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.0041;
     #elif BOARD_MODEL == BOARD_HELTEC32_V4
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.00418;
+    #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+      // The board pin map specifies VBAT = Vbat_Read * 4.9.
+      float battery_measurement = (float)(analogRead(pin_vbat)) / 4095.0 * 3.3 * 4.9;
     #elif BOARD_MODEL == BOARD_T3S3
       float battery_measurement = (float)(analogRead(pin_vbat)) / 4095.0*6.7828;
     #elif BOARD_MODEL == BOARD_HELTEC_T114
@@ -460,6 +480,11 @@ bool init_pmu() {
     return true;
   #elif BOARD_MODEL == BOARD_HELTEC32_V4
     pinMode(pin_ctrl,OUTPUT);
+    digitalWrite(pin_ctrl, HIGH);
+    return true;
+  #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+    pinMode(pin_vbat, INPUT);
+    pinMode(pin_ctrl, OUTPUT);
     digitalWrite(pin_ctrl, HIGH);
     return true;
   #elif BOARD_MODEL == BOARD_HELTEC_T114

--- a/README.md
+++ b/README.md
@@ -65,20 +65,27 @@ pio run -t fullclean
 Build a single environment (board):
 ```
 pio run -e ttgo-t-beam
+pio run -e heltec-wireless-tracker-v2
 pio run -e wiscore_rak4631
 ```
 
 Build and upload a single environment (board):
 ```
 pio run -e ttgo-t-beam -t upload
+pio run -e heltec-wireless-tracker-v2 -t upload
 pio run -e wiscore_rak4631 -t upload
 ```
 
 Build and package a single environment (board):
 ```
 pio run -e ttgo-t-beam -t package
+pio run -e heltec-wireless-tracker-v2 -t package
 pio run -e wiscore_rak4631 -t package
 ```
+
+On erased EEPROM, the Heltec Wireless Tracker V2 enables BLE and explicitly
+disables Wi-Fi; later user choices are preserved. Radio parameters remain unset
+until a user selects region-appropriate values.
 
 Build all environments (boards):
 ```

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -482,8 +482,11 @@ void setup() {
     }
     delay(10);
   }
-  // CBA Test
-  delay(2000);
+  // Native USB opens reset the Tracker V2. Keep its startup short enough to
+  // answer rnodeconf's EEPROM request before the utility times out.
+  #if BOARD_MODEL != BOARD_HELTEC_TRACKER_V2
+    delay(2000);
+  #endif
 
 #ifdef HAS_RNS
   printf("Total SRAM:  %7u bytes\n", RNS::Utilities::Memory::heap_size());
@@ -595,7 +598,7 @@ void setup() {
     boot_seq();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_RAK3401 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_HELTEC32_V4
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_RAK3401 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_HELTEC32_V4 && BOARD_MODEL != BOARD_HELTEC_TRACKER_V2
     // Some boards need to wait until the hardware UART is set up before booting
     // the full firmware. In the case of the RAK4631, RAK3401, and Heltec T114,
     // the line below will wait until a serial connection is actually established
@@ -777,6 +780,19 @@ void setup() {
   #if MCU_VARIANT == MCU_ESP32 || MCU_VARIANT == MCU_NRF52 || MCU_VARIANT == MCU_NATIVE
     #if HAS_PMU == true
       pmu_ready = init_pmu();
+    #endif
+
+    // Seed only erased Tracker V2 settings. Explicit user choices (including
+    // disabling BLE) are represented by non-0xFF values and remain intact.
+    // Radio parameters intentionally remain unset because frequency and power
+    // require a region-appropriate choice during onboarding.
+    #if BOARD_MODEL == BOARD_HELTEC_TRACKER_V2 && HAS_EEPROM
+      if (EEPROM.read(eeprom_addr(ADDR_CONF_BT)) == 0xFF) {
+        eeprom_update(eeprom_addr(ADDR_CONF_BT), BT_ENABLE_BYTE);
+      }
+      if (EEPROM.read(eeprom_addr(ADDR_CONF_WIFI)) == 0xFF) {
+        eeprom_update(eeprom_addr(ADDR_CONF_WIFI), WR_WIFI_OFF);
+      }
     #endif
 
     #if HAS_BLUETOOTH || HAS_BLE == true
@@ -2315,7 +2331,7 @@ int  noise_floor_buffer[NOISE_FLOOR_SAMPLES] = {0};
 void update_noise_floor() {
   #if MCU_VARIANT == MCU_ESP32 || MCU_VARIANT == MCU_NRF52 || MCU_VARIANT == MCU_NATIVE
     if (!dcd) {
-      #if BOARD_MODEL != BOARD_HELTEC32_V4
+      #if HAS_LORA_LNA == false
       if (!noise_floor_sampled || current_rssi < noise_floor + CSMA_INFR_THRESHOLD_DB) {
       #else
       if ((!noise_floor_sampled || current_rssi < noise_floor + CSMA_INFR_THRESHOLD_DB) || (noise_floor_sampled && (noise_floor < LNA_GD_THRSHLD && current_rssi <= LNA_GD_LIMIT))) {
@@ -2365,7 +2381,7 @@ void update_modem_status() {
     portEXIT_CRITICAL();
   #endif
 
-  #if BOARD_MODEL == BOARD_HELTEC32_V4
+  #if HAS_LORA_LNA
     if (noise_floor > LNA_GD_THRSHLD)  { interference_detected = !carrier_detected && (current_rssi > (noise_floor+CSMA_INFR_THRESHOLD_DB)); }
     else                               { interference_detected = !carrier_detected && (current_rssi > LNA_GD_LIMIT); }
   #else
@@ -2790,6 +2806,12 @@ void sleep_now() {
           digitalWrite(LORA_PA_CSD, LOW);
           digitalWrite(LORA_PA_PWR_EN, LOW);
           digitalWrite(Vext, HIGH);
+      #endif
+      #if BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+          digitalWrite(LORA_PA_CTX, LOW);
+          digitalWrite(LORA_PA_CSD, LOW);
+          digitalWrite(LORA_PA_PWR_EN, LOW);
+          digitalWrite(Vext, VEXT_OFF);
       #endif
       #if PIN_DISP_SLEEP >= 0
         pinMode(PIN_DISP_SLEEP, OUTPUT);

--- a/RNode_Firmware.ino
+++ b/RNode_Firmware.ino
@@ -130,6 +130,7 @@ void update_airtime();
 void update_modem_status();
 void buffer_serial();
 void serial_poll();
+void work_while_waiting();
 
 #ifdef HAS_RNS
 /*
@@ -1077,8 +1078,8 @@ void setup() {
       HEAD("Creating Reticulum instance...", RNS::LOG_TRACE);
       reticulum = RNS::Reticulum();
       // CBA NOTE: `transport_enabled` needs to always be overridden to false when op_mode is not MODE_TNC
-printf("hw_ready: %u\n", hw_ready);
-printf("op_mode: %U\n", op_mode);
+printf("[init] hw_ready: %u\n", hw_ready);
+printf("[init] op_mode: %U\n", op_mode);
       if (op_mode != MODE_TNC) {
         INFO("Not in TNC mode, transport will be disabled");
         reticulum.transport_enabled(false);

--- a/Utilities.h
+++ b/Utilities.h
@@ -341,6 +341,13 @@ extern RNS::Reticulum reticulum;
 			void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
 			void led_id_on()  { }
 			void led_id_off() { }
+	#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+			void led_rx_on()  { }
+			void led_rx_off() { }
+			void led_tx_on()  { }
+			void led_tx_off() { }
+			void led_id_on()  { }
+			void led_id_off() { }
 	#elif BOARD_MODEL == BOARD_LORA32_V2_1
 		void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
 		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
@@ -1461,6 +1468,7 @@ void setTXPower() {
 		if (model == MODEL_C5) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 		if (model == MODEL_CA) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 		if (model == MODEL_C8) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
+		if (model == MODEL_CB) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 
 		if (model == MODEL_D4) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
 		if (model == MODEL_D9) LoRa->setTxPower(mapped_lora_txp, PA_OUTPUT_PA_BOOST_PIN);
@@ -1729,7 +1737,7 @@ bool eeprom_product_valid() {
 	#if PLATFORM == PLATFORM_AVR
 	if (rval == PRODUCT_RNODE || rval == PRODUCT_HMBRW) {
 	#elif PLATFORM == PLATFORM_ESP32
-	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_H32_V4 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1  || rval == PRODUCT_XIAO_S3) {
+	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_H32_V4 || rval == PRODUCT_HTRACKER_V2 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1  || rval == PRODUCT_XIAO_S3) {
 	#elif PLATFORM == PLATFORM_NRF52
 	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW) {
 	#elif PLATFORM == PLATFORM_NATIVE
@@ -1782,6 +1790,8 @@ bool eeprom_model_valid() {
 	if (model == MODEL_C5 || model == MODEL_CA) {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V4
 	if (model == MODEL_C8) {
+	#elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
+	if (model == MODEL_CB) {
   #elif BOARD_MODEL == BOARD_HELTEC_T114
   if (model == MODEL_C6 || model == MODEL_C7) {
   #elif BOARD_MODEL == BOARD_RAK4631

--- a/boards/heltec-wireless-tracker-v2.json
+++ b/boards/heltec-wireless-tracker-v2.json
@@ -1,0 +1,53 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_HELTEC_WIRELESS_TRACKER_V2",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "lora"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Heltec Wireless Tracker V2",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://heltec.org/project/wireless-tracker-v2/",
+  "vendor": "Heltec"
+}

--- a/extra_script.py
+++ b/extra_script.py
@@ -3,6 +3,8 @@ import hashlib
 import shutil
 import platform as platformlib
 
+from firmware_image import esp_image_sha256, firmware_hash_kiss_frame
+
 #
 # Helpier functions
 #
@@ -120,6 +122,22 @@ def device_wipe(env):
     print("--- Wiping Device ---")
     env.Execute("rnodeconf --eeprom-wipe " + env.subst("$UPLOAD_PORT"))
 
+def device_set_firmware_hash(firmware_hash, env):
+    import serial
+
+    port_path = env.subst("$UPLOAD_PORT")
+    frame = firmware_hash_kiss_frame(firmware_hash)
+    print("Writing firmware hash directly over KISS for unsupported rnodeconf model...")
+    with serial.Serial(port_path, 115200, timeout=0.1) as port:
+        # Opening native USB resets the Tracker V2. Drain startup output and
+        # wait until setup() has reached the serial command loop.
+        ready_at = time.monotonic() + 4.0
+        while time.monotonic() < ready_at:
+            port.read(4096)
+        port.write(frame)
+        port.flush()
+        time.sleep(1)
+
 def device_provision(env):
     # Device provision
     print("--- Provisioning Device ---")
@@ -136,6 +154,8 @@ def device_provision(env):
             env.Execute("rnodeconf --product b1 --model b9 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "heltec32v4pa" | "heltec32v4pa_local":
             env.Execute("rnodeconf --product c3 --model c8 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
+        case "heltec_tracker_v2" | "heltec_tracker_v2_local":
+            env.Execute("rnodeconf --product c4 --model cb --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "rak4631" | "rak4631_local":
             env.Execute("rnodeconf --product 10 --model 12 --hwrev 1 --rom " + env.subst("$UPLOAD_PORT"))
         case "rak3401" | "rak3401_local":
@@ -167,14 +187,23 @@ def firmware_hash(source, env):
     else:
         print("source_file:", source_file)
         firmware_data = open(source_file, "rb").read()
-        calc_hash = hashlib.sha256(firmware_data[0:-32]).digest()
-        part_hash = firmware_data[-32:]
-        hex_hash = calc_hash.hex()
-        print("firmware_hash:", hex_hash)
-        if (calc_hash == part_hash):
-            env.Execute("rnodeconf --firmware-hash " + hex_hash + " " + env.subst("$UPLOAD_PORT"))
+        if env.GetProjectOption("custom_variant") in ("heltec_tracker_v2", "heltec_tracker_v2_local"):
+            try:
+                calc_hash = esp_image_sha256(firmware_data)
+            except ValueError as error:
+                print(f"Unable to calculate firmware hash: {error}")
+                return
+            print("firmware_hash:", calc_hash.hex())
+            device_set_firmware_hash(calc_hash, env)
         else:
-            print("Calculated hash does not match!")
+            calc_hash = hashlib.sha256(firmware_data[0:-32]).digest()
+            part_hash = firmware_data[-32:]
+            hex_hash = calc_hash.hex()
+            print("firmware_hash:", hex_hash)
+            if calc_hash == part_hash:
+                env.Execute("rnodeconf --firmware-hash " + hex_hash + " " + env.subst("$UPLOAD_PORT"))
+            else:
+                print("Calculated hash does not match!")
 
 def firmware_package(env):
     # Firmware package

--- a/firmware_image.py
+++ b/firmware_image.py
@@ -1,0 +1,47 @@
+import hashlib
+
+
+ESP_IMAGE_MAGIC = 0xE9
+ESP_IMAGE_HEADER_SIZE = 24
+ESP_IMAGE_HASH_APPENDED_OFFSET = 23
+SHA256_SIZE = 32
+KISS_FEND = 0xC0
+KISS_FESC = 0xDB
+KISS_TFEND = 0xDC
+KISS_TFESC = 0xDD
+KISS_CMD_FIRMWARE_HASH = 0x58
+
+
+def esp_image_sha256(image: bytes) -> bytes:
+    """Return the digest produced by esp_partition_get_sha256() for an app image."""
+    if len(image) < ESP_IMAGE_HEADER_SIZE:
+        raise ValueError("ESP application image is shorter than its header")
+    if image[0] != ESP_IMAGE_MAGIC:
+        raise ValueError("firmware is not an ESP application image")
+
+    hash_appended = image[ESP_IMAGE_HASH_APPENDED_OFFSET] == 1
+    if not hash_appended:
+        return hashlib.sha256(image).digest()
+
+    if len(image) < ESP_IMAGE_HEADER_SIZE + SHA256_SIZE:
+        raise ValueError("ESP application image is missing its appended SHA-256")
+
+    content = image[:-SHA256_SIZE]
+    appended_hash = image[-SHA256_SIZE:]
+    calculated_hash = hashlib.sha256(content).digest()
+    if calculated_hash != appended_hash:
+        raise ValueError("ESP application image has an invalid appended SHA-256")
+
+    return appended_hash
+
+
+def firmware_hash_kiss_frame(firmware_hash: bytes) -> bytes:
+    if len(firmware_hash) != SHA256_SIZE:
+        raise ValueError("firmware hash must be exactly 32 bytes")
+
+    escaped_hash = firmware_hash.replace(
+        bytes([KISS_FESC]), bytes([KISS_FESC, KISS_TFESC])
+    ).replace(
+        bytes([KISS_FEND]), bytes([KISS_FESC, KISS_TFEND])
+    )
+    return bytes([KISS_FEND, KISS_CMD_FIRMWARE_HASH]) + escaped_hash + bytes([KISS_FEND])

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,7 @@ default_envs =
 	heltec_wifi_lora_32_V2-extled
 	heltec_wifi_lora_32_V3
 	heltec_wifi_lora_32_V4
+	heltec-wireless-tracker-v2
 	featheresp32
 	seeed_xiao_esp32s3
 	generic-esp32
@@ -774,6 +775,52 @@ lib_deps =
 	XPowersLib@^0.2.1
 	https://github.com/attermann/microStore.git
 	https://github.com/attermann/microReticulum.git
+
+; MCU: ESP32-S3 (ESP32-S3FN8)
+; SRAM: 512 KB
+; PSRAM: N/A
+; Flash: 8 MB
+; External Flash Interface: N/A
+; Display: 0.96-inch 80x160 ST7735-compatible TFT
+; LoRa: Semtech SX1262 with KCT8103L FEM, up to 28 dBm
+[env:heltec-wireless-tracker-v2]
+extends = env:embedded
+; Pin the official PlatformIO distribution because the firmware BLE transport
+; uses Arduino-ESP32's Bluedroid API. The Tasmota 2.0.14 package selected by
+; some global PlatformIO installations is built for NimBLE instead.
+platform = platformio/espressif32 @ 7.0.0
+board = heltec-wireless-tracker-v2
+custom_variant = heltec_tracker_v2
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+board_build.partitions = default_8MB.csv
+board_build.filesystem = littlefs
+lib_ignore =
+	SD
+	Adafruit seesaw Library
+build_flags =
+	${env:embedded.build_flags}
+	-DBOARD_MODEL=BOARD_HELTEC_TRACKER_V2
+	-DUSTORE_USE_POSIXFS=1
+	-DURTN_PATH_TABLE_MAX_RECS=500
+	-DRNS_PATH_TABLE_SEGMENT_SIZE=24576 ; 24 KB
+	-DRNS_PATH_TABLE_SEGMENT_COUNT=8
+lib_deps =
+	${env:embedded-esp32.lib_deps}
+	adafruit/Adafruit ST7735 and ST7789 Library@^1.10.4
+	https://github.com/attermann/microStore.git
+	https://github.com/attermann/microReticulum.git
+monitor_filters = esp32_exception_decoder
+upload_speed = 921600
+
+[env:heltec-wireless-tracker-v2-local]
+extends = env:heltec-wireless-tracker-v2
+custom_variant = heltec_tracker_v2_local
+lib_deps =
+	${env:embedded-esp32.lib_deps}
+	adafruit/Adafruit ST7735 and ST7789 Library@^1.10.4
+	https://github.com/attermann/microStore.git
+	microReticulum=symlink://../microReticulum
 
 ; MCU: ESP32
 ; SRAM: 520 KB

--- a/platformio.ini
+++ b/platformio.ini
@@ -788,7 +788,8 @@ extends = env:embedded
 ; Pin the official PlatformIO distribution because the firmware BLE transport
 ; uses Arduino-ESP32's Bluedroid API. The Tasmota 2.0.14 package selected by
 ; some global PlatformIO installations is built for NimBLE instead.
-platform = platformio/espressif32 @ 7.0.0
+platform = espressif32
+;platform = platformio/espressif32 @ 7.0.0
 board = heltec-wireless-tracker-v2
 custom_variant = heltec_tracker_v2
 board_upload.flash_size = 8MB

--- a/sx126x.cpp
+++ b/sx126x.cpp
@@ -140,7 +140,7 @@ bool sx126x::preInit() {
   pinMode(_ss, OUTPUT);
   digitalWrite(_ss, HIGH);
 
-  #if BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_XIAO_S3
+  #if BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_HELTEC_TRACKER_V2 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_XIAO_S3
     SPI.begin(pin_sclk, pin_miso, pin_mosi, pin_cs);
   #elif BOARD_MODEL == BOARD_TECHO
     SPI.setPins(pin_miso, pin_sclk, pin_mosi);
@@ -841,6 +841,8 @@ void sx126x::enableTCXO() {
         #elif BOARD_MODEL == BOARD_TECHO
           mode = MODE_TCXO_1_8V_6X;
         #elif BOARD_MODEL == BOARD_HELTEC32_V4
+          mode = MODE_TCXO_1_8V_6X;
+        #elif BOARD_MODEL == BOARD_HELTEC_TRACKER_V2
           mode = MODE_TCXO_1_8V_6X;
         #endif
       }

--- a/tests/test_firmware_image.py
+++ b/tests/test_firmware_image.py
@@ -1,0 +1,56 @@
+import hashlib
+import unittest
+
+from firmware_image import esp_image_sha256, firmware_hash_kiss_frame
+
+
+def make_image(payload: bytes, *, hash_appended: bool) -> bytes:
+    header = bytearray(24)
+    header[0] = 0xE9
+    header[23] = int(hash_appended)
+    content = bytes(header) + payload
+    if hash_appended:
+        return content + hashlib.sha256(content).digest()
+    return content
+
+
+class EspImageSha256Tests(unittest.TestCase):
+    def test_hashes_complete_image_without_appended_hash(self):
+        image = make_image(b"firmware", hash_appended=False)
+
+        self.assertEqual(esp_image_sha256(image), hashlib.sha256(image).digest())
+
+    def test_returns_valid_appended_hash(self):
+        image = make_image(b"firmware", hash_appended=True)
+
+        self.assertEqual(esp_image_sha256(image), image[-32:])
+
+    def test_rejects_invalid_appended_hash(self):
+        image = make_image(b"firmware", hash_appended=True)
+        damaged_image = image[:-1] + bytes([image[-1] ^ 0xFF])
+
+        with self.assertRaisesRegex(ValueError, "invalid appended SHA-256"):
+            esp_image_sha256(damaged_image)
+
+    def test_rejects_non_esp_image(self):
+        with self.assertRaisesRegex(ValueError, "not an ESP application image"):
+            esp_image_sha256(bytes(24))
+
+
+class FirmwareHashKissFrameTests(unittest.TestCase):
+    def test_frames_and_escapes_firmware_hash(self):
+        firmware_hash = bytes([0xC0, 0xDB]) + bytes(range(30))
+
+        frame = firmware_hash_kiss_frame(firmware_hash)
+
+        self.assertEqual(frame[:2], bytes([0xC0, 0x58]))
+        self.assertEqual(frame[2:6], bytes([0xDB, 0xDC, 0xDB, 0xDD]))
+        self.assertEqual(frame[-1], 0xC0)
+
+    def test_rejects_incorrect_hash_length(self):
+        with self.assertRaisesRegex(ValueError, "exactly 32 bytes"):
+            firmware_hash_kiss_frame(bytes(31))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webconsole/index.html
+++ b/webconsole/index.html
@@ -305,8 +305,8 @@ const BOARD_NAMES = {
   0x36:'TTGO LoRa32 v2.0', 0x37:'TTGO LoRa32 v2.1', 0x38:'Heltec LoRa32 v2', 0x39:'TTGO LoRa32 v1.0',
   0x3A:'Heltec LoRa32 v3', 0x3B:'LilyGO T-Deck', 0x3C:'Heltec T114', 0x3D:'T-Beam Supreme',
   0x3E:'XIAO ESP32-S3', 0x3F:'Heltec LoRa32 v4', 0x40:'RNode v2.0', 0x41:'RNode v2.1',
-  0x42:'T3S3', 0x44:'LilyGO T-Echo', 0x50:'Generic nRF52', 0x51:'WisCore RAK4631', 0x52:'WisCore RAK3401',
-  0x60:'Native Linux',
+  0x42:'T3S3', 0x44:'LilyGO T-Echo', 0x45:'Heltec Wireless Tracker V2',
+  0x50:'Generic nRF52', 0x51:'WisCore RAK4631', 0x52:'WisCore RAK3401', 0x60:'Native Linux',
 };
 // CONF_OK marker indicating the device boots into TNC mode.
 const CONF_OK_BYTE = 0x73;


### PR DESCRIPTION
Add board, product, and model identifiers.
Configure the ESP32-S3 and onboard SX1262 pin mapping.
Add KCT8103L PA/LNA front-end control and output-gain configuration.
Add support for the onboard 160x80 ST7735-compatible TFT.
Configure Vext, display backlight, user button, and battery measurement.
Add standard and local PlatformIO environments.
Enable BLE by default on erased EEPROM while leaving Wi-Fi disabled.
Add provisioning and firmware-hash handling for the new model.
Add the Tracker V2 name to the web console.

RAK3401: display + LNA gain-drift, minor cleanups
- Add LNA_GD_THRSHLD/LIMIT for RAK3401 matching HELTEC32_V4
  (gain drift is an SX1262 RX-chain trait, not FEM-specific)
- Enable SSD1306 pins and landscape rotation for RAK3401
  (shares the RAK4631 branch); reorder HELTEC_TRACKER_V2 blocks so
  the T114 branch is reachable
- Forward-declare work_while_waiting(); tag init
  printfs with [init] prefix
- Unpin espressif32 for heltec-wireless-tracker-v2
  (use the default platform alias)